### PR TITLE
Use actual application version instead of hardcoded string.

### DIFF
--- a/KMPCommon.cs
+++ b/KMPCommon.cs
@@ -6,7 +6,14 @@ using System.Text;
 public class KMPCommon
 {
 
-	public const String PROGRAM_VERSION = "0.1.0";
+	public String PROGRAM_VERSION
+    {
+        get
+        {
+            return Assembly.GetExecutingAssembly().GetName().Version.ToString();
+        }
+    }
+
 	public const Int32 FILE_FORMAT_VERSION = 10000;
 	public const Int32 NET_PROTOCOL_VERSION = 10000;
 	public const int MSG_HEADER_LENGTH = 8;
@@ -39,24 +46,12 @@ public class KMPCommon
 
 	public static byte[] intToBytes(Int32 val)
 	{
-		byte[] bytes = new byte[4];
-		bytes[0] = (byte)(val & byte.MaxValue);
-		bytes[1] = (byte)((val >> 8) & byte.MaxValue);
-		bytes[2] = (byte)((val >> 16) & byte.MaxValue);
-		bytes[3] = (byte)((val >> 24) & byte.MaxValue);
-
-		return bytes;
+        return BitConverter.GetBytes(val);
 	}
 
 	public static Int32 intFromBytes(byte[] bytes, int offset = 0)
 	{
-		Int32 val = 0;
-		val |= bytes[offset];
-		val |= ((Int32)bytes[offset + 1]) << 8;
-		val |= ((Int32)bytes[offset + 2]) << 16;
-		val |= ((Int32)bytes[offset + 3]) << 24;
-
-		return val;
+        return BitConverter.ToInt32(bytes, offset);
 	}
 
 	public enum ClientMessageID


### PR DESCRIPTION
Bitconverter instead of shifting. (No need to reinvent the wheel)
