### PR TITLE
Checking for required external assemblies

### DIFF
--- a/KLFServer/ServerMain.cs
+++ b/KLFServer/ServerMain.cs
@@ -69,9 +69,23 @@ namespace KMPServer
             Log.Info("/whitelist [add|del] [user] to update whitelist.");
             Log.Info("/quit to exit, or /start to begin the server.");
             Log.Info("");
-
+            
+            if(!File.Exists("Assembly-CSharp.dll"))
+            {
+            	Log.Error("REQUIRED ASSEMBLY: Assembly-CSharp.dll not present in working directory. Please refer to readme.")
+            }
+            if(!File.Exists("Assembly-CSharp-firstpass.dll"))
+            {
+            	Log.Error("REQUIRED ASSEMBLY: Assembly-CSharp-firstpass.dll not present in working directory. Please refer to readme.")
+            }
+            if(!File.Exists("UnityEngine.dll"))
+            {
+            	Log.Error("REQUIRED ASSEMBLY: UnityEngine.dll not present in working directory. Please refer to readme.")
+            }
+            
+            
             bool running = true;
-
+	    
             while (running)
             {
                 var line = Console.ReadLine();

--- a/KLFServer/ServerMain.cs
+++ b/KLFServer/ServerMain.cs
@@ -72,15 +72,15 @@ namespace KMPServer
             
             if(!File.Exists("Assembly-CSharp.dll"))
             {
-            	Log.Error("REQUIRED ASSEMBLY: Assembly-CSharp.dll not present in working directory. Please refer to readme.")
+            	Log.Error("REQUIRED ASSEMBLY: Assembly-CSharp.dll not present in working directory. Please refer to readme.");
             }
             if(!File.Exists("Assembly-CSharp-firstpass.dll"))
             {
-            	Log.Error("REQUIRED ASSEMBLY: Assembly-CSharp-firstpass.dll not present in working directory. Please refer to readme.")
+            	Log.Error("REQUIRED ASSEMBLY: Assembly-CSharp-firstpass.dll not present in working directory. Please refer to readme.");
             }
             if(!File.Exists("UnityEngine.dll"))
             {
-            	Log.Error("REQUIRED ASSEMBLY: UnityEngine.dll not present in working directory. Please refer to readme.")
+            	Log.Error("REQUIRED ASSEMBLY: UnityEngine.dll not present in working directory. Please refer to readme.");
             }
             
             


### PR DESCRIPTION
This is a solution to issue https://github.com/TehGimp/KerbalMultiPlayer/issues/11 (which I had)

It checks for the 3 unity/ksp assemblies that are needed for the server and logs errors if they do not exist.

I'm presuming that this is a fair check as I doubt that windows is going to be finding these assemblies outside of the directory at run time.
