### PR TITLE
checking for sqlite3.dll at launch

### DIFF
--- a/KLFServer/ServerMain.cs
+++ b/KLFServer/ServerMain.cs
@@ -82,7 +82,10 @@ namespace KMPServer
             {
             	Log.Error("REQUIRED ASSEMBLY: UnityEngine.dll not present in working directory. Please refer to readme.");
             }
-            
+            if(!File.Exists("sqlite3.dll"))
+            {
+            	Log.Error("REQUIRED ASSEMBLY: sqlite3.dll not present in working directory. Please refer to readme.");
+            }
             
             bool running = true;
 	    


### PR DESCRIPTION
sqlite3.dll does not seem to be installable to windows so this check should suffice

http://stackoverflow.com/questions/1734629/installing-sqlite-3-6-on-windows-7
