### PR TITLE
Make mouse0 binding to GUI toggle impossible

### DIFF
--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -2684,8 +2684,11 @@ namespace KMP
 					KeyCode key = KeyCode.F7;
 					if (getAnyKeyDown(ref key))
 					{
-						KMPGlobalSettings.instance.guiToggleKey = key;
-						mappingGUIToggleKey = false;
+						if (key != KeyCode.Mouse0)
+						{
+							KMPGlobalSettings.instance.guiToggleKey = key;
+							mappingGUIToggleKey = false;
+						}
 					}
 				}
 	


### PR DESCRIPTION
Having Mouse0 bound to toggle the menu left the UI in an unusable state, requiring settings to be deleted.  This change should abort the rebinding process if Mouse0 is pressed rather than binding it.
