### PR TITLE
Changed the sharecraft command from / to ! and added it to the !help command output.

### DIFF
--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -710,21 +710,21 @@ namespace KMP
 			{
 				if (quitHelperMessageShow && (line == "q" || line == "Q"))
 				{
-					enqueuePluginChatMessage("If you are trying to quit, use the /quit command.", true);
+					enqueuePluginChatMessage("If you are trying to quit, use the !quit command.", true);
 					quitHelperMessageShow = false;
 				}
 
-				if (line.ElementAt(0) == '/')
+				if (line.ElementAt(0) == '!')
 				{
 					String line_lower = line.ToLower();
 
-					if (line_lower == "/quit")
+					if (line_lower == "!quit")
 					{
 						intentionalConnectionEnd = true;
 						endSession = true;
 						sendConnectionEndMessage("Quit");
 					}
-					else if (line_lower == "/ping")
+					else if (line_lower == "!ping")
 					{
 						if (!pingStopwatch.IsRunning)
 						{
@@ -732,7 +732,7 @@ namespace KMP
 							pingStopwatch.Start();
 						}
 					}
-					else if (line_lower == "/debug")
+					else if (line_lower == "!debug")
 					{
 						debugging = !debugging;
 						enqueuePluginChatMessage("debug " + debugging);

--- a/KMPCommon.cs
+++ b/KMPCommon.cs
@@ -28,7 +28,7 @@ public class KMPCommon
 
 	public const int MAX_CRAFT_FILE_BYTES = 1024 * 1024;
 
-	public const String SHARE_CRAFT_COMMAND = "/sharecraft";//"/" chat commands handled by client
+	public const String SHARE_CRAFT_COMMAND = "!sharecraft";//"/" chat commands handled by client
 	public const String GET_CRAFT_COMMAND = "!getcraft";	//"!" chat commands handled by server
 
 	public const byte CRAFT_TYPE_VAB = 0;

--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -2054,8 +2054,8 @@ namespace KMPServer
                         sb.Append("!help - Displays this message\n");
                         sb.Append("!list - View all connected players\n");
                         sb.Append("!quit - Leaves the server\n");
-                        sb.Append("!sharecraft <craftname> - Shares the craft of name <craftname> with all other players\n")
-                        sb.Append("!getcraft <playername> - Gets the most recent craft shared by the specified player\n");
+                        sb.Append(SHARE_CRAFT_COMMAND + " <craftname> - Shares the craft of name <craftname> with all other players\n")
+                        sb.Append(GET_CRAFT_COMMAND + " <playername> - Gets the most recent craft shared by the specified player\n");
                         sb.Append("!motd - Displays Server MOTD\n");
                         sb.Append("!rules - Displays Server Rules\n");
                         sb.Append(Environment.NewLine);

--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -2054,6 +2054,7 @@ namespace KMPServer
                         sb.Append("!help - Displays this message\n");
                         sb.Append("!list - View all connected players\n");
                         sb.Append("!quit - Leaves the server\n");
+                        sb.Append("!sharecraft <craftname> - Shares the craft of name <craftname> with all other players\n")
                         sb.Append("!getcraft <playername> - Gets the most recent craft shared by the specified player\n");
                         sb.Append("!motd - Displays Server MOTD\n");
                         sb.Append("!rules - Displays Server Rules\n");


### PR DESCRIPTION
Hi there!  I noticed that the !help command in chat didn't say anything about how to share a craft file, and then with a little more research was perplexed to find that the /sharecraft command seems to be the only chat command preceded by a slash instead of an exclamation point.

I changed that, and added details about sharecraft to the output of the !help command.

Hope you'll like the idea!  Please feel free to tell me if there's something I'm don't know here that makes this all not make sense.
