### PR TITLE
Hide the add server form after addition in connection window

### DIFF
--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -3405,6 +3405,10 @@ namespace KMP
 							
 							if (String.IsNullOrEmpty(favorites[i]) || i == 7) {
 								favorites[i] = newHost.Trim() + ":" + newPort.Trim();
+
+                                //Close the add server bar after a server has been added and select the new server
+							    addPressed = false;
+                                KMPConnectionDisplay.activeHostname = favorites[i];
 								break;
 							}
 						}


### PR DESCRIPTION
Hide the add server form after addition in the connection window after the server is added to the favourites list, and select the new server in the list.
