### PR TITLE
Add httpBroadcast server key

### DIFF
--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -328,21 +328,9 @@ namespace KMPServer
 				autoDekesslerTimer = new Timer(_ => dekesslerServerCommand(new string[0]), null, settings.autoDekesslerTime * 60000, settings.autoDekesslerTime * 60000);
 				Log.Debug("Starting AutoDekessler: Timer Set to " + settings.autoDekesslerTime + " Minutes");
 			}
-            
-            //Begin listening for HTTP requests
 
-            httpListener = new HttpListener(); //Might need a replacement as HttpListener needs admin rights
-            try
-            {
-                httpListener.Prefixes.Add("http://*:" + settings.httpPort + '/');
-                httpListener.Start();
-                httpListener.BeginGetContext(asyncHTTPCallback, httpListener);
-            }
-            catch (Exception e)
-            {
-                Log.Error("Error starting http server: {0}", e);
-                Log.Error("Please try running the server as an administrator");
-            }
+            if (settings.httpBroadcast)
+                startHttpServer();
 
             long last_backup_time = 0;
 
@@ -380,6 +368,28 @@ namespace KMPServer
             Log.Info("Server session ended.");
             if (quit) { Log.Info("Quitting"); Thread.Sleep(1000); Environment.Exit(0); }
 
+        }
+
+        private void startHttpServer()
+        {
+            //Begin listening for HTTP requests
+            httpListener = new HttpListener(); //Might need a replacement as HttpListener needs admin rights
+            try
+            {
+                httpListener.Prefixes.Add("http://*:" + settings.httpPort + '/');
+                httpListener.Start();
+                httpListener.BeginGetContext(asyncHTTPCallback, httpListener);
+            }
+            catch (Exception e)
+            {
+                Log.Error("Error starting http server: {0}", e);
+                Log.Error("Please try running the server as an administrator");
+            }
+        }
+
+        private void killHttpServer()
+        {
+            httpListener.Stop();
         }
 
         private void handleCommands()

--- a/KMPServer/ServerSettings.cs
+++ b/KMPServer/ServerSettings.cs
@@ -32,6 +32,7 @@ namespace KMPServer
 			public string ipBinding = "0.0.0.0";
 			public int port = 2076;
 			public int httpPort = 8081;
+            public bool httpBroadcast = true;
 			public int maxClients = 8;
 			public float updatesPerSecond = 60;
 			public int screenshotInterval = 3000;
@@ -50,6 +51,7 @@ namespace KMPServer
 			public double safetyBubbleRadius = 20000d;
             public bool autoDekessler = false;
             public int autoDekesslerTime = 30;
+            
 
 			private List<BanRecord> _bans = new List<BanRecord>();
 			internal List<BanRecord> bans


### PR DESCRIPTION
Allows the server operator to choose to disallow an httpServer to
broadcast the KMP information, effectively allowing "private" or
"hidden" servers.  Requires server restart
