### PR TITLE
Initial IPv6 support

### DIFF
--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -337,7 +337,33 @@ namespace KMP
                 }
                 if (host_entry != null)
                 {
-                    address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
+                    if (System.Net.Sockets.Socket.OSSupportsIPv6 == true) {
+                        //This is a test to see if the client has IPv6 connectivity. May not be correct but this is the only way to make sure.
+                        IPAddress ipv6_test_address = null;
+                        try {
+                        ipv6_test_address = host_entry.AddressList.First();
+                        TcpClient ipv6_test_tcpClient = new TcpClient(AddressFamily.InterNetworkV6);
+                        IPEndPoint ipv6_test_endpoint = new IPEndPoint(ipv6_test_address, port);
+                            try {
+                                ipv6_test_tcpClient.Connect(ipv6_test_endpoint);
+                                if (ipv6_test_tcpClient.Client.Connected) {
+                                    address = ipv6_test_address;
+                                } else {
+                                    address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
+                                }
+                            }
+                            catch (Exception) {
+                                address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
+                            }
+                        }
+                        catch (SocketException) {
+                            address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
+                        }
+                        catch (ArgumentException) {
+                            address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);}
+                    } else {
+                        address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
+                    }
                 }
             }
 
@@ -349,16 +375,23 @@ namespace KMP
 
             IPEndPoint endpoint = new IPEndPoint(address, port);
 
-            SetMessage("Connecting to server: " + address + ":" + port);
+            SetMessage("Connecting to server: " + address + " port " + port);
 
             try
             {
-                TcpClient tcpClient = new TcpClient();
-                tcpClient.NoDelay = true;
-                tcpClient.Connect(endpoint);
-                tcpSocket = tcpClient.Client;
+                
+                if (System.Net.Sockets.Socket.OSSupportsIPv6 == true && endpoint.AddressFamily == AddressFamily.InterNetworkV6) {
+                    TcpClient tcpClient = new TcpClient(AddressFamily.InterNetworkV6);
+                    tcpClient.NoDelay = true;
+                    tcpClient.Connect(endpoint);
+                    tcpSocket = tcpClient.Client;
+                } else {
+                    TcpClient tcpClient = new TcpClient(AddressFamily.InterNetwork);
+                    tcpClient.NoDelay = true;
+                    tcpClient.Connect(endpoint);
+                    tcpSocket = tcpClient.Client;
+                }
                 //tcpSocket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.KeepAlive, true);
-
                 if (tcpSocket.Connected)
                 {
                     SetMessage("TCP connection established");
@@ -393,8 +426,13 @@ namespace KMP
                     //Init udp socket
                     try
                     {
-                        udpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-                        udpSocket.Connect(endpoint);
+                        if (System.Net.Sockets.Socket.OSSupportsIPv6 == true && endpoint.AddressFamily == AddressFamily.InterNetworkV6) {
+                            udpSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
+                            udpSocket.Connect(endpoint);
+                        } else {
+                            udpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+                            udpSocket.Connect(endpoint);
+                        }
                     }
                     catch
                     {
@@ -455,7 +493,7 @@ namespace KMP
             {
                 SetMessage("Disconnected");
                 if (tcpSocket != null)
-                    tcpSocket.Close();
+                   tcpSocket.Close();
 
                 tcpSocket = null;
             }

--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -327,11 +327,7 @@ namespace KMP
                 {
                     host_entry = Dns.GetHostEntry(trimmed_hostname);
                 }
-                catch (SocketException)
-                {
-                    host_entry = null;
-                }
-                catch (ArgumentException)
+                catch (Exception e)
                 {
                     host_entry = null;
                 }
@@ -341,26 +337,20 @@ namespace KMP
                         //This is a test to see if the client has IPv6 connectivity. May not be correct but this is the only way to make sure.
                         IPAddress ipv6_test_address = null;
                         try {
-                        ipv6_test_address = host_entry.AddressList.First();
-                        TcpClient ipv6_test_tcpClient = new TcpClient(AddressFamily.InterNetworkV6);
-                        IPEndPoint ipv6_test_endpoint = new IPEndPoint(ipv6_test_address, port);
-                            try {
-                                ipv6_test_tcpClient.Connect(ipv6_test_endpoint);
-                                if (ipv6_test_tcpClient.Client.Connected) {
-                                    address = ipv6_test_address;
-                                } else {
-                                    address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
-                                }
-                            }
-                            catch (Exception) {
+                            ipv6_test_address = host_entry.AddressList.First();
+                            TcpClient ipv6_test_tcpClient = new TcpClient(AddressFamily.InterNetworkV6);
+                            IPEndPoint ipv6_test_endpoint = new IPEndPoint(ipv6_test_address, port);
+                            ipv6_test_tcpClient.Connect(ipv6_test_endpoint);
+                            if (ipv6_test_tcpClient.Client.Connected) {
+                                address = ipv6_test_address;
+                                ipv6_test_tcpClient.Close();
+                            } else {
                                 address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
                             }
                         }
-                        catch (SocketException) {
+                        catch (Exception e) {
                             address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
                         }
-                        catch (ArgumentException) {
-                            address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);}
                     } else {
                         address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
                     }

--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -301,14 +301,24 @@ namespace KMPServer
             ghostCheckThread = new Thread(new ThreadStart(checkGhosts));
 
             threadException = null;
-
+            if (settings.ipBinding == "0.0.0.0" && settings.hostIPv6 == true) {
+                settings.ipBinding = "::";
+            }
             tcpListener = new TcpListener(IPAddress.Parse(settings.ipBinding), settings.port);
+            
             listenThread.Start();
 
             try
             {
-                udpClient = new UdpClient(settings.port);
-                udpClient.BeginReceive(asyncUDPReceive, null);
+                if (settings.hostIPv6 == true) {
+                    udpClient = new UdpClient(settings.port, AddressFamily.InterNetworkV6);
+                    udpClient.BeginReceive(asyncUDPReceive, null);
+                    //udpClient.Client.AllowNatTraversal(1);
+                } else {
+                    udpClient = new UdpClient(settings.port, AddressFamily.InterNetwork);
+                    udpClient.BeginReceive(asyncUDPReceive, null);
+                }
+                
             }
             catch
             {
@@ -868,6 +878,7 @@ namespace KMPServer
             {
                 Log.Info("Listening for clients...");
                 tcpListener.Start(4);
+                
                 while (true)
                 {
 
@@ -1220,7 +1231,9 @@ namespace KMPServer
         {
             try
             {
-
+                if (settings.ipBinding == "0.0.0.0" && settings.hostIPv6 == true) {
+                    settings.ipBinding = "::";
+                }
                 IPEndPoint endpoint = new IPEndPoint(IPAddress.Parse(settings.ipBinding), settings.port);
                 if (udpClient == null) { return; }
                 byte[] received = udpClient.EndReceive(result, ref endpoint);

--- a/KMPServer/ServerSettings.cs
+++ b/KMPServer/ServerSettings.cs
@@ -39,6 +39,7 @@ namespace KMPServer
 			public bool autoRestart = false;
 			public bool autoHost = false;
 			public bool saveScreenshots = true;
+			public bool hostIPv6 = false;
 			public String joinMessage = String.Empty;
 			public String serverInfo = String.Empty;
 			public String serverMotd = String.Empty;


### PR DESCRIPTION
This is more a request for comments, everything appears to work. Don't merge this until after 1.4 has been released just to be safe.

The only problem is people with broken IPv6 will fail to connect to servers that have proper AAAA records. (that's people with a non-working default route, can be simulated with ip6tables -A OUTPUT -p tcp --dport 2076 -j DROP). However they would also have problems connecting to google and facebook, so it's kinda their problem. I can't specify a timeout on the connect call without doing async stuff :(.

None of the public servers listed have AAAA records the last time I checked (about a week ago)

It even works with mygen.ca (doesn't connect to ipv6, uses ipv4 instead). That guy needs to get his DNS fixed...
mygen.ca has IPv6 address fe80::16da:e9ff:fe08:88dd

EDIT: Forgot to reference bug #381
