### PR TITLE
IPv6 Support. This fixes issue #381

### DIFF
--- a/KMPServer/ServerSettings.cs
+++ b/KMPServer/ServerSettings.cs
@@ -39,6 +39,7 @@ namespace KMPServer
 			public bool autoRestart = false;
 			public bool autoHost = false;
 			public bool saveScreenshots = true;
+			public bool hostIPv6 = false;
 			public String joinMessage = String.Empty;
 			public String serverInfo = String.Empty;
 			public String serverMotd = String.Empty;


### PR DESCRIPTION
This adds full IPv6 support, including adding a server by IPv6 address and DNS. Currently it sends a probe to see if it can connect to IPv6 before doing so. Broken IPv6 (people with a non working default route) will suffer however.

Squashed and rebased for easy committing :)
