### PR TITLE
Admin markers in chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 # Monodevelop project stuff
 **/*.userprefs
 **/*.pidb
+*.userprefs
+bin
 
 # Windows runtime
 *.exe

--- a/KMPChatDX.cs
+++ b/KMPChatDX.cs
@@ -55,29 +55,35 @@ namespace KMP
             public String name;
             public String message;
             public Color color;
+			public bool isAdmin;
 
             public ChatLine(String line)
             {
                 this.color = Color.yellow;
                 this.name = "";
                 this.message = line;
+				this.isAdmin = false;
 
                 //Check if the message has a name
-                if (line.Length > 3 && line.First() == '<')
+                if (line.Length > 3 && (line.First() == '<' || (line.StartsWith("["+KMPCommon.ADMIN_MARKER+"]") && line.Contains('<'))))
                 {
-                    int name_length = line.IndexOf('>');
+					int name_start = line.IndexOf('<');
+                    int name_end = line.IndexOf('>');
+					int name_length = name_end - name_start - 1;
                     if (name_length > 0)
                     {
-                        name_length = name_length - 1;
-                        this.name = line.Substring(1, name_length);
-                        this.message = line.Substring(name_length + 2);
+                        this.name = line.Substring(name_start+1, name_length);
+                        this.message = line.Substring(name_end + 1);
 
                         if (this.name == "Server")
                             this.color = Color.magenta;
-                        else this.color = KMPVessel.generateActiveColor(name) * NAME_COLOR_SATURATION_FACTOR
+						else if (line.StartsWith("["+KMPCommon.ADMIN_MARKER+"]")) {
+							this.color = Color.red;
+							this.isAdmin = true;
+						} else this.color = KMPVessel.generateActiveColor(name) * NAME_COLOR_SATURATION_FACTOR
                             + Color.white * (1.0f - NAME_COLOR_SATURATION_FACTOR);
                     }
-                } 
+                }
             }
         }
 

--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -337,7 +337,7 @@ namespace KMP
                 {
                     host_entry = Dns.GetHostEntry(trimmed_hostname);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     host_entry = null;
                 }
@@ -358,7 +358,7 @@ namespace KMP
                                 address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
                             }
                         }
-                        catch (Exception e) {
+                        catch (Exception) {
                             address = host_entry.AddressList.First(a => a.AddressFamily == AddressFamily.InterNetwork);
                         }
                     } else {

--- a/KMPCommon.cs
+++ b/KMPCommon.cs
@@ -32,6 +32,8 @@ public class KMPCommon
 	public const String GET_CRAFT_COMMAND = "!getcraft";	//"!" chat commands handled by server
 	public const String RCON_COMMAND = "!rcon";
 
+	public const String ADMIN_MARKER = "@";
+
 	public const byte CRAFT_TYPE_VAB = 0;
 	public const byte CRAFT_TYPE_SPH = 1;
 

--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -3931,7 +3931,10 @@ namespace KMP
                 }
                 else
                 {
-                    var text = line.name + ": " + line.message;
+					var text = line.name + ": " + line.message;
+					if(line.isAdmin) {
+						text = "[" + KMPCommon.ADMIN_MARKER + "] " + text;
+					}
                     GUILayout.Label(text, KMPChatDX.chatStyle);
 
                     var position = GUILayoutUtility.GetLastRect();

--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -2216,7 +2216,7 @@ namespace KMPServer
                 if (settings.profanityFilter)
                     message_text = WashMouthWithSoap(message_text);
 
-                string full_message = string.Format("<{0}> {1}", cl.username, message_text);
+				string full_message = string.Format("{2}<{0}> {1}", cl.username, message_text, (isAdmin(cl.username) ? "["+KMPCommon.ADMIN_MARKER+"] " : ""));
 
                 //Console.SetCursorPosition(0, Console.CursorTop);
                 Log.Chat(cl.username, message_text);


### PR DESCRIPTION
Admins will be marked with [@] in chat, and will have red color.

Sorry about formatting, MonoDevelop does this in a strange way.
