### PR TITLE
logging path fix for non-windows

### DIFF
--- a/KMPServer/Logger.cs
+++ b/KMPServer/Logger.cs
@@ -8,8 +8,7 @@ namespace KMPServer
 {
     public static class Log
     {
-        private static string LogFolder = @"logs\";
-        private static string LogFilename =  LogFolder + "kmpserver " + DateTime.Now.ToString("dd-MM-yyyy HH-mm-ss") + ".log";
+        private static string LogFilename =  Path.Combine("logs", "kmpserver " + DateTime.Now.ToString("dd-MM-yyyy HH-mm-ss") + ".log");
         
         public enum LogLevels : int
         {

--- a/KMPServer/Logger.cs
+++ b/KMPServer/Logger.cs
@@ -8,7 +8,8 @@ namespace KMPServer
 {
     public static class Log
     {
-        private static string LogFilename =  Path.Combine("logs", "kmpserver " + DateTime.Now.ToString("dd-MM-yyyy HH-mm-ss") + ".log");
+        private static string LogFolder = "logs";
+        private static string LogFilename =  Path.Combine(LogFolder, "kmpserver " + DateTime.Now.ToString("dd-MM-yyyy HH-mm-ss") + ".log");
         
         public enum LogLevels : int
         {


### PR DESCRIPTION
the hardcoded '\' was not recognized by systems that used a '/', Path.Combine on mono will notice this and change
