### PR TITLE
Added System.Core to csproj files

### DIFF
--- a/KMPServer/KMPServer.csproj
+++ b/KMPServer/KMPServer.csproj
@@ -49,6 +49,7 @@
     <Reference Include="MySql.Data">
       <HintPath>..\mysql.data.dll</HintPath>
     </Reference>
+    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DBExtensions.cs" />

--- a/KerbalMultiPlayer.csproj
+++ b/KerbalMultiPlayer.csproj
@@ -46,6 +46,7 @@
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
+    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="KMPChatDX.cs" />


### PR DESCRIPTION
Monodevelop doesn't include System.Core by default so it wouldn't know any of the namespaces it includes such as System.Linq.

This fixes the problem.
