### PR TITLE
Fix for bug #422

### DIFF
--- a/KMPServer/KMPServer.csproj
+++ b/KMPServer/KMPServer.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -89,6 +89,9 @@
     <None Include="Service References\ServerList\Report1.xsd">
       <SubType>Designer</SubType>
     </None>
+    <None Include="sqlite3.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Service References\" />
@@ -111,7 +114,4 @@
       <LastGenOutput>Reference.cs</LastGenOutput>
     </None>
   </ItemGroup>
-  <Target Name="BeforeBuild">
-    <Copy SourceFiles="sqlite3.dll" DestinationFolder="$(OutDir)" />
-  </Target>
 </Project>


### PR DESCRIPTION
We must have serious formatting issues with this whole dos/unix format thing. That's why it shows the first and last lines changed.

This makes sqllite3 appear in the correct folder using monodevelop. It _should_ also work for visual studio, but a windows user is going to have to test that.
