### PR TITLE
Server Sided Mod Control (Resource whitelist/blacklist, MD5 control, required mod list, parts list)

### DIFF
--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -4,6 +4,10 @@ using System.Linq;
 using System.Text;
 using System.Globalization;
 
+using System.Security.Cryptography;
+using System.Runtime.Serialization.Formatters.Binary;
+//using System.IO AS OF 0.21 THIS HAS BEEN REENABLED, WE DON'T NEED TO USE KSP.IO ANYMORE
+
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -44,10 +48,10 @@ namespace KMP
 
         //public const String INTEROP_CLIENT_FILENAME = "interopclient.txt";
         //public const String INTEROP_PLUGIN_FILENAME = "interopplugin.txt";
-        public const String CLIENT_CONFIG_FILENAME = "KMPClientConfig.xml";
-        public const String CLIENT_TOKEN_FILENAME = "KMPPlayerToken.txt";
-        public const String PART_LIST_FILENAME = "KMPPartList.txt";
-        public const String CRAFT_FILE_EXTENSION = ".craft";
+        public const string CLIENT_CONFIG_FILENAME = "KMPClientConfig.xml";
+        public const string CLIENT_TOKEN_FILENAME = "KMPPlayerToken.txt";
+        public const string MOD_CONTROL_FILENAME = "KMPModControl.txt";
+        public const string CRAFT_FILE_EXTENSION = ".craft";
 
         public const int MAX_USERNAME_LENGTH = 16;
         public const int MAX_TEXT_MESSAGE_QUEUE = 128;
@@ -96,7 +100,18 @@ namespace KMP
         public static byte inactiveShipsPerUpdate = 0;
         public static ScreenshotSettings screenshotSettings = new ScreenshotSettings();
 		public static Dictionary<String, String[]> favorites = new Dictionary<String, String[]>();
-
+		
+		//ModChecking
+		public static bool modFileChecked = false;
+		public static List<string> partList = new List<string>();
+        public static Dictionary<string, string> md5List = new Dictionary<string, string>(); //path:md5
+        public static List<string> resourceList = new List<string>();
+        public static List<string> requiredModList = new List<string>();
+		public static string resourceControlMode = "blacklist";
+		public static string modMismatchError = "Mod Verification Failed - Reason Unknown";
+		public static string GAMEDATAPATH = new System.IO.DirectoryInfo(getKMPDirectory()).Parent.Parent.FullName;
+        public static byte[] kmpModControl_bytes;
+		
         //Connection
         public static int clientID;
         public static bool endSession;
@@ -176,7 +191,6 @@ namespace KMP
         public static bool debugging = true;
         public static bool cheatsEnabled = false;
 
-        public static List<string> partList = new List<string>();
 
 
         public static void InitMPClient(KMPManager manager)
@@ -248,9 +262,261 @@ namespace KMP
             favorites = newFavorites;
             writeConfigFile();
         }
+        
+        private static string doHashMD5(MD5 md5, byte[] tohash)
+        {
+        	byte[] hashed = md5.ComputeHash(tohash);
+
+            StringBuilder sBuilder = new StringBuilder();
+
+            // Loop through each byte of the hashed data  
+            // and format each one as a hexadecimal string. 
+            for (int i = 0; i < hashed.Length; i++)
+            {
+                sBuilder.Append(hashed[i].ToString("x2"));
+            }
+			
+            return sBuilder.ToString();
+        }
+        
+        private static void parseModFile(string modfilepath)
+        {
+        	System.IO.StreamReader reader = System.IO.File.OpenText(modfilepath);
+        	
+	        string resourcemode = "blacklist";
+	        List<string> allowedParts = new List<string>();
+	        Dictionary<string, string> hashes = new Dictionary<string, string>();
+	        List<string> resources = new List<string>();
+	        List<string> modList = new List<string>();
+	        string line;
+	        string[] splitline;
+	        string readmode = "parts";
+	        while (reader.Peek() != -1)
+	        {
+	        	
+	        	line = reader.ReadLine();
+	        	
+	        	try
+	        	{
+		        	if(line[0] != '#')//allows commented lines
+		        	{	
+		        		if(line[0] == '!')//changing readmode
+		        		{
+		        			if(line.Contains("partslist")){
+		        				readmode = "parts";
+		        			}
+		        			else if(line.Contains("md5")){
+		        				readmode = "md5";
+		        			}
+		        			else if(line.Contains("resource-blacklist")){ //allow all resources EXCEPT these in file
+		        				readmode = "resource";
+		        				resourcemode = "blacklist";
+		        			}
+		        			else if(line.Contains("resource-whitelist")){ //allow NO resources EXCEPT these in file
+		        				readmode = "resource";
+		        				resourcemode = "whitelist";
+		        			}
+		        			else if(line.Contains("required")){
+		        				readmode = "required";
+		        			}
+		        		}
+		        		else if(readmode == "parts")
+		        		{
+		        			allowedParts.Add(line);
+		        		}
+		        		else if(readmode == "md5")
+		        		{
+		        			splitline = line.Split('=');
+		        			hashes.Add(splitline[0], splitline[1]); //stores path:md5
+		        		}
+		        		else if(readmode == "resource"){
+		        			resources.Add(line);
+		        		}
+		        		else if(readmode == "required"){
+		        			modList.Add(line);
+		        		}
+		        	}
+		        }
+		        catch (Exception e)
+		        {
+		        	Log.Info(e.ToString());
+		        }
+	        }
+	        
+	        reader.Close();
+	        partList = allowedParts; //make all the vars global once we're done parsing
+	        md5List = hashes;
+	        resourceControlMode = resourcemode;
+	        resourceList = resources;
+	        requiredModList = modList;
+	        
+        }
+        
+        private static bool md5Check()
+        {
+        	string md5Hash;
+        	string hashPath;
+        	byte[] toHash;
+        	foreach (KeyValuePair<string, string> entry in md5List)
+        	{
+        		hashPath = System.IO.Path.Combine(GAMEDATAPATH, entry.Key);
+        		
+	        	MD5 md5 = MD5.Create();
+	        	
+	        	try
+	        	{
+	        		toHash = System.IO.File.ReadAllBytes(hashPath);
+	        	}
+	        	catch (System.IO.FileNotFoundException)
+	        	{
+	        		modMismatchError = "Required File Missing: " + System.IO.Path.GetFileName(hashPath);
+	        		return false;
+	        	}
+	        	catch (System.IO.DirectoryNotFoundException)
+	        	{
+	        		string dir = hashPath;
+	        		while(new System.IO.DirectoryInfo(dir).Parent.Name != "GameData")
+	        		{
+	        			dir = new System.IO.DirectoryInfo(dir).Parent.FullName;
+	        		}
+	        		modMismatchError = "Required Mod Missing or Incomplete: " + new System.IO.DirectoryInfo(dir).Name;
+	        		return false;
+	        	}
+	        	catch (System.IO.IsolatedStorage.IsolatedStorageException) //EXACTLY the same as directory not found, but thrown for the same reason (why?)
+	        	{
+	        		string dir = hashPath;
+	        		while(new System.IO.DirectoryInfo(dir).Parent.Name != "GameData")
+	        		{
+	        			dir = new System.IO.DirectoryInfo(dir).Parent.FullName;
+	        		}
+	        		modMismatchError = "Required Mod Missing or Incomplete: " + new System.IO.DirectoryInfo(dir).Name;
+	        		return false;
+	        	}
+	        	catch (Exception e)
+	        	{
+		        	Log.Info(e.ToString());
+		        	return false;
+	        	}
+	        	
+	        	md5Hash = doHashMD5(md5, toHash);
+	        	if (md5Hash != entry.Value.ToLower())
+	        	{
+	        		string failedFile = System.IO.Path.GetFileName(hashPath);
+	        		modMismatchError = "MD5 Checksum Mismatch: " + failedFile;
+	        		return false;
+	        	}
+	        }
+	        return true;
+	    }
+        
+        
+        private static bool resourceCheck()
+        {
+        	try
+        	{
+        		string[] ls = System.IO.Directory.GetFiles(GAMEDATAPATH, "*.*", System.IO.SearchOption.AllDirectories);
+	        	if(resourceControlMode == "blacklist")
+	        	{
+	        		foreach(string checkedResource in resourceList)
+	        		{
+	        			foreach(string resource in ls)
+	        			{
+	        				if(resource.Contains(checkedResource))
+	        				{
+	        					modMismatchError = "Resource Blacklisted: " + new System.IO.DirectoryInfo(resource).Name;
+	        					return false;
+	        				}
+	        			}
+	        		}
+	        	}
+	        	else if(resourceControlMode == "whitelist")
+	        	{
+	        		foreach(string resource in ls)
+	        		{
+	        			if(resource.Contains(".dll") && !((resource.Contains("KerbalMultiPlayer.dll") 
+	        			|| resource.Contains("ICSharpCode.SharpZipLib.dll")) && resource.Contains("KMP")))//is .dll the ONLY type we need to worry about? 
+	        			{
+	        				bool allowed = false;
+	        				foreach(string checkedResource in resourceList)
+	        				{
+	        					if(resource.Contains(checkedResource))
+	        					{
+									allowed = true;
+									break;
+	        					}
+	        				}
+	        				if(!allowed)
+	        				{
+	        					modMismatchError = "Resource Not On Whitelist: " + new System.IO.DirectoryInfo(resource).Name;
+	        					return false;
+	        				}
+	        			}
+	        		}
+	        	}
+	        	return true;
+	        }
+	        catch (Exception e)
+	        {
+	        	Log.Info(e.ToString());
+	        	return false;
+	        }
+        }
+        
+        private static bool requiredCheck()
+        {
+        	string[] ls = System.IO.Directory.GetDirectories(GAMEDATAPATH);
+        	bool found;
+        	foreach (string required in requiredModList)
+        	{
+        		found = false;
+        		
+	        	foreach (string resource in ls)
+	        	{
+	        		if (required == new System.IO.DirectoryInfo(resource).Name)
+	        		{
+	        			found = true;
+	        			break;
+	        		}
+	        	}
+	        	if (!found)
+	        	{
+	        		modMismatchError = "Missing Required Mod: " + required;
+	        		return false;
+	        	}
+	        }
+        	
+        	return true;
+        }
+        
+        private static bool modCheck(byte[] kmpModControl_bytes)
+        {	
+        	if (!modFileChecked)
+        	{
+        		modFileChecked = true;
+				string modFilePath = System.IO.Path.Combine(GAMEDATAPATH, "KMP/Plugins/PluginData/KerbalMultiPlayer/" + MOD_CONTROL_FILENAME);
+	        	System.IO.File.WriteAllBytes(modFilePath, kmpModControl_bytes);
+	        	
+				parseModFile(modFilePath);
+	        	
+	        	if (!md5Check() || !resourceCheck() || !requiredCheck())
+	        	{
+	        		return false;
+	        	}
+	        	else
+	        	{
+	        		return true;
+	        	}
+
+        	}
+        	else
+        	{
+        		return true;
+        	}
+        }
 
         public static void Connect()
         {
+        	modFileChecked = false;
             clearConnectionState();
             File.Delete<KMPClientMain>("debug");
             serverThread = new Thread(beginConnect);
@@ -522,6 +788,11 @@ namespace KMP
                         {
                             String server_version = encoder.GetString(data, 8, server_version_length);
                             clientID = KMPCommon.intFromBytes(data, 8 + server_version_length);
+                            //I don't know exactly why we check the size of the handshake message because messages are only parsed here if they are sent in full. Can't understand that checking business there
+                            int kmpModControl_length = KMPCommon.intFromBytes(data, 8 + server_version_length + 4);
+                            kmpModControl_bytes = new byte[kmpModControl_length];
+                            Array.Copy(data, 8 + server_version_length + 4 + 4 , kmpModControl_bytes, 0, kmpModControl_length);
+                                
 
                             SetMessage("Handshake received. Server version: " + server_version);
                         }
@@ -536,12 +807,21 @@ namespace KMP
                     }
                     else
                     {
-                        sendHandshakeMessage(); //Reply to the handshake
-                        lock (udpTimestampLock)
+                        if (!modCheck(kmpModControl_bytes))
                         {
-                            lastUDPMessageSendTime = stopwatch.ElapsedMilliseconds;
+                            endSession = true;
+                            intentionalConnectionEnd = true;
+                            gameManager.disconnect(modMismatchError);
                         }
-                        handshakeCompleted = true;
+                        else
+                        {
+                            sendHandshakeMessage(); //Reply to the handshake
+                            lock (udpTimestampLock)
+                            {
+                                lastUDPMessageSendTime = stopwatch.ElapsedMilliseconds;
+                            }
+                            handshakeCompleted = true;
+                        }
                     }
 
                     break;
@@ -597,7 +877,7 @@ namespace KMP
                     break;
 
                 case KMPCommon.ServerMessageID.SERVER_SETTINGS:
-
+                	
                     lock (serverSettingsLock)
                     {
                         if (data != null && data.Length >= KMPCommon.SERVER_SETTINGS_LENGTH && handshakeCompleted)
@@ -624,6 +904,8 @@ namespace KMP
                                     lastClientDataChangeTime = stopwatch.ElapsedMilliseconds;
                                 }
                                 cheatsEnabled = Convert.ToBoolean(data[21]);
+                                //partList, requiredModList, md5List, resourceList and resourceControlMode 
+
                             }
 
                             receivedSettings = true;
@@ -1667,100 +1949,6 @@ namespace KMP
 
         }
 
-
-        //Reads the parts list file
-        private static void readPartsList()
-        {
-            try
-            {
-                //Get the part list if available
-                KSP.IO.TextReader reader = KSP.IO.File.OpenText<KMPClientMain>(PART_LIST_FILENAME);
-                List<string> lines = new List<string>();
-                while (!reader.EndOfStream)
-                {
-                    lines.Add(reader.ReadLine());
-                }
-                reader.Close();
-                partList = lines;
-
-                bool changed = false;
-                if (!lines.Contains("kerbalEVA"))
-                {
-                    partList.Add("kerbalEVA");
-                    changed = true;
-                }
-                if (!lines.Contains("flag"))
-                {
-                    partList.Add("flag");
-                    changed = true;
-                }
-                if (changed)
-                {
-                    KSP.IO.TextWriter writer = KSP.IO.File.CreateText<KMPClientMain>(PART_LIST_FILENAME);
-                    foreach (string part in partList)
-                        writer.WriteLine(part);
-                    writer.Close();
-                }
-            }
-            catch (Exception e)
-            {
-                KMP.Log.Debug("Exception thrown in readPartsList(), catch 1, Exception: {0}", e.ToString());
-                //Generate the stock part list
-                partList = new List<string>();
-
-                //0.21 (& below) parts
-                partList.Add("StandardCtrlSrf"); partList.Add("CanardController"); partList.Add("noseCone"); partList.Add("AdvancedCanard"); partList.Add("airplaneTail");
-                partList.Add("deltaWing"); partList.Add("noseConeAdapter"); partList.Add("rocketNoseCone"); partList.Add("smallCtrlSrf"); partList.Add("standardNoseCone");
-                partList.Add("sweptWing"); partList.Add("tailfin"); partList.Add("wingConnector"); partList.Add("winglet"); partList.Add("R8winglet");
-                partList.Add("winglet3"); partList.Add("Mark1Cockpit"); partList.Add("Mark2Cockpit"); partList.Add("Mark1-2Pod"); partList.Add("advSasModule");
-                partList.Add("asasmodule1-2"); partList.Add("avionicsNoseCone"); partList.Add("crewCabin"); partList.Add("cupola"); partList.Add("landerCabinSmall");
-
-                partList.Add("mark3Cockpit"); partList.Add("mk1pod"); partList.Add("mk2LanderCabin"); partList.Add("probeCoreCube"); partList.Add("probeCoreHex");
-                partList.Add("probeCoreOcto"); partList.Add("probeCoreOcto2"); partList.Add("probeCoreSphere"); partList.Add("probeStackLarge"); partList.Add("probeStackSmall");
-                partList.Add("sasModule"); partList.Add("seatExternalCmd"); partList.Add("rtg"); partList.Add("batteryBank"); partList.Add("batteryBankLarge");
-                partList.Add("batteryBankMini"); partList.Add("batteryPack"); partList.Add("ksp.r.largeBatteryPack"); partList.Add("largeSolarPanel"); partList.Add("solarPanels1");
-                partList.Add("solarPanels2"); partList.Add("solarPanels3"); partList.Add("solarPanels4"); partList.Add("solarPanels5"); partList.Add("JetEngine");
-
-                partList.Add("engineLargeSkipper"); partList.Add("ionEngine"); partList.Add("liquidEngine"); partList.Add("liquidEngine1-2"); partList.Add("liquidEngine2");
-                partList.Add("liquidEngine2-2"); partList.Add("liquidEngine3"); partList.Add("liquidEngineMini"); partList.Add("microEngine"); partList.Add("nuclearEngine");
-                partList.Add("radialEngineMini"); partList.Add("radialLiquidEngine1-2"); partList.Add("sepMotor1"); partList.Add("smallRadialEngine"); partList.Add("solidBooster");
-                partList.Add("solidBooster1-1"); partList.Add("toroidalAerospike"); partList.Add("turboFanEngine"); partList.Add("MK1Fuselage"); partList.Add("Mk1FuselageStructural");
-                partList.Add("RCSFuelTank"); partList.Add("RCSTank1-2"); partList.Add("rcsTankMini"); partList.Add("rcsTankRadialLong"); partList.Add("fuelTank");
-
-                partList.Add("fuelTank1-2"); partList.Add("fuelTank2-2"); partList.Add("fuelTank3-2"); partList.Add("fuelTank4-2"); partList.Add("fuelTankSmall");
-                partList.Add("fuelTankSmallFlat"); partList.Add("fuelTank.long"); partList.Add("miniFuelTank"); partList.Add("mk2Fuselage"); partList.Add("mk2SpacePlaneAdapter");
-                partList.Add("mk3Fuselage"); partList.Add("mk3spacePlaneAdapter"); partList.Add("radialRCSTank"); partList.Add("toroidalFuelTank"); partList.Add("xenonTank");
-                partList.Add("xenonTankRadial"); partList.Add("adapterLargeSmallBi"); partList.Add("adapterLargeSmallQuad"); partList.Add("adapterLargeSmallTri"); partList.Add("adapterSmallMiniShort");
-                partList.Add("adapterSmallMiniTall"); partList.Add("nacelleBody"); partList.Add("radialEngineBody"); partList.Add("smallHardpoint"); partList.Add("stationHub");
-
-                partList.Add("structuralIBeam1"); partList.Add("structuralIBeam2"); partList.Add("structuralIBeam3"); partList.Add("structuralMiniNode"); partList.Add("structuralPanel1");
-                partList.Add("structuralPanel2"); partList.Add("structuralPylon"); partList.Add("structuralWing"); partList.Add("strutConnector"); partList.Add("strutCube");
-                partList.Add("strutOcto"); partList.Add("trussAdapter"); partList.Add("trussPiece1x"); partList.Add("trussPiece3x"); partList.Add("CircularIntake");
-                partList.Add("landingLeg1"); partList.Add("landingLeg1-2"); partList.Add("RCSBlock"); partList.Add("stackDecoupler"); partList.Add("airScoop");
-                partList.Add("commDish"); partList.Add("decoupler1-2"); partList.Add("dockingPort1"); partList.Add("dockingPort2"); partList.Add("dockingPort3");
-
-                partList.Add("dockingPortLarge"); partList.Add("dockingPortLateral"); partList.Add("fuelLine"); partList.Add("ladder1"); partList.Add("largeAdapter");
-                partList.Add("largeAdapter2"); partList.Add("launchClamp1"); partList.Add("linearRcs"); partList.Add("longAntenna"); partList.Add("miniLandingLeg");
-                partList.Add("parachuteDrogue"); partList.Add("parachuteLarge"); partList.Add("parachuteRadial"); partList.Add("parachuteSingle"); partList.Add("radialDecoupler");
-                partList.Add("radialDecoupler1-2"); partList.Add("radialDecoupler2"); partList.Add("ramAirIntake"); partList.Add("roverBody"); partList.Add("sensorAccelerometer");
-                partList.Add("sensorBarometer"); partList.Add("sensorGravimeter"); partList.Add("sensorThermometer"); partList.Add("spotLight1"); partList.Add("spotLight2");
-
-                partList.Add("stackBiCoupler"); partList.Add("stackDecouplerMini"); partList.Add("stackPoint1"); partList.Add("stackQuadCoupler"); partList.Add("stackSeparator");
-                partList.Add("stackSeparatorBig"); partList.Add("stackSeparatorMini"); partList.Add("stackTriCoupler"); partList.Add("telescopicLadder"); partList.Add("telescopicLadderBay");
-                partList.Add("SmallGearBay"); partList.Add("roverWheel1"); partList.Add("roverWheel2"); partList.Add("roverWheel3"); partList.Add("wheelMed"); partList.Add("flag");
-                partList.Add("kerbalEVA");
-
-                //0.22 parts
-                partList.Add("mediumDishAntenna"); partList.Add("GooExperiment"); partList.Add("science.module");
-
-                //Write to disk
-                KSP.IO.TextWriter writer = KSP.IO.File.CreateText<KMPClientMain>(PART_LIST_FILENAME);
-                foreach (string part in partList)
-                    writer.WriteLine(part);
-                writer.Close();
-            }
-        }
-
         // Reads the player's token (GUID)
         private static void readTokenFile()
         {
@@ -1850,7 +2038,7 @@ namespace KMP
             }
 
             readTokenFile();
-            readPartsList();
+            //readPartsList(); now server sided
         }
 
         static void writeConfigFile()

--- a/KMPCommon.cs
+++ b/KMPCommon.cs
@@ -18,13 +18,13 @@ public class KMPCommon
     }
 
 	public const Int32 FILE_FORMAT_VERSION = 10000;
-	public const Int32 NET_PROTOCOL_VERSION = 10006;
+	public const Int32 NET_PROTOCOL_VERSION = 10008;
 	public const int MSG_HEADER_LENGTH = 8;
     public const int MAX_MESSAGE_SIZE = 1024 * 1024; //Enough room for a max-size craft file
 	public const int MESSAGE_COMPRESSION_THRESHOLD = 4096;
 	public const int INTEROP_MSG_HEADER_LENGTH = 8;
 
-	public const int SERVER_SETTINGS_LENGTH = 22;
+	public const int SERVER_SETTINGS_LENGTH = 22; //Length of fixed position information. Variable length settings start after this (including the header).
 
 	public const int MAX_CRAFT_FILE_BYTES = 1024 * 1024;
 

--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -1,4 +1,4 @@
-﻿//#define DEBUG_OUT
+//#define DEBUG_OUT
 //#define SEND_UPDATES_TO_SENDER
 
 using System;
@@ -50,6 +50,9 @@ namespace KMPServer
         public const String SCREENSHOT_DIR = "KMPScreenshots";
         public const string DB_FILE_CONN = "Data Source=KMP_universe.db";
         public const string DB_FILE = "KMP_universe.db";
+        public const string MOD_CONTROL_FILE = "KMPModControl.txt";
+        
+        public static byte[] kmpModControl;
 
         public const int UNIVERSE_VERSION = 3;
 
@@ -220,7 +223,119 @@ namespace KMPServer
 
             startDatabase();
         }
+        
+		private static void generatePartsList(TextWriter writer)
+        {
+                List<string> partList = new List<string>();
 
+                //0.21 (& below) parts
+                partList.Add("StandardCtrlSrf"); partList.Add("CanardController"); partList.Add("noseCone"); partList.Add("AdvancedCanard"); partList.Add("airplaneTail");
+                partList.Add("deltaWing"); partList.Add("noseConeAdapter"); partList.Add("rocketNoseCone"); partList.Add("smallCtrlSrf"); partList.Add("standardNoseCone");
+                partList.Add("sweptWing"); partList.Add("tailfin"); partList.Add("wingConnector"); partList.Add("winglet"); partList.Add("R8winglet");
+                partList.Add("winglet3"); partList.Add("Mark1Cockpit"); partList.Add("Mark2Cockpit"); partList.Add("Mark1-2Pod"); partList.Add("advSasModule");
+                partList.Add("asasmodule1-2"); partList.Add("avionicsNoseCone"); partList.Add("crewCabin"); partList.Add("cupola"); partList.Add("landerCabinSmall");
+
+                partList.Add("mark3Cockpit"); partList.Add("mk1pod"); partList.Add("mk2LanderCabin"); partList.Add("probeCoreCube"); partList.Add("probeCoreHex");
+                partList.Add("probeCoreOcto"); partList.Add("probeCoreOcto2"); partList.Add("probeCoreSphere"); partList.Add("probeStackLarge"); partList.Add("probeStackSmall");
+                partList.Add("sasModule"); partList.Add("seatExternalCmd"); partList.Add("rtg"); partList.Add("batteryBank"); partList.Add("batteryBankLarge");
+                partList.Add("batteryBankMini"); partList.Add("batteryPack"); partList.Add("ksp.r.largeBatteryPack"); partList.Add("largeSolarPanel"); partList.Add("solarPanels1");
+                partList.Add("solarPanels2"); partList.Add("solarPanels3"); partList.Add("solarPanels4"); partList.Add("solarPanels5"); partList.Add("JetEngine");
+
+                partList.Add("engineLargeSkipper"); partList.Add("ionEngine"); partList.Add("liquidEngine"); partList.Add("liquidEngine1-2"); partList.Add("liquidEngine2");
+                partList.Add("liquidEngine2-2"); partList.Add("liquidEngine3"); partList.Add("liquidEngineMini"); partList.Add("microEngine"); partList.Add("nuclearEngine");
+                partList.Add("radialEngineMini"); partList.Add("radialLiquidEngine1-2"); partList.Add("sepMotor1"); partList.Add("smallRadialEngine"); partList.Add("solidBooster");
+                partList.Add("solidBooster1-1"); partList.Add("toroidalAerospike"); partList.Add("turboFanEngine"); partList.Add("MK1Fuselage"); partList.Add("Mk1FuselageStructural");
+                partList.Add("RCSFuelTank"); partList.Add("RCSTank1-2"); partList.Add("rcsTankMini"); partList.Add("rcsTankRadialLong"); partList.Add("fuelTank");
+
+                partList.Add("fuelTank1-2"); partList.Add("fuelTank2-2"); partList.Add("fuelTank3-2"); partList.Add("fuelTank4-2"); partList.Add("fuelTankSmall");
+                partList.Add("fuelTankSmallFlat"); partList.Add("fuelTank.long"); partList.Add("miniFuelTank"); partList.Add("mk2Fuselage"); partList.Add("mk2SpacePlaneAdapter");
+                partList.Add("mk3Fuselage"); partList.Add("mk3spacePlaneAdapter"); partList.Add("radialRCSTank"); partList.Add("toroidalFuelTank"); partList.Add("xenonTank");
+                partList.Add("xenonTankRadial"); partList.Add("adapterLargeSmallBi"); partList.Add("adapterLargeSmallQuad"); partList.Add("adapterLargeSmallTri"); partList.Add("adapterSmallMiniShort");
+                partList.Add("adapterSmallMiniTall"); partList.Add("nacelleBody"); partList.Add("radialEngineBody"); partList.Add("smallHardpoint"); partList.Add("stationHub");
+
+                partList.Add("structuralIBeam1"); partList.Add("structuralIBeam2"); partList.Add("structuralIBeam3"); partList.Add("structuralMiniNode"); partList.Add("structuralPanel1");
+                partList.Add("structuralPanel2"); partList.Add("structuralPylon"); partList.Add("structuralWing"); partList.Add("strutConnector"); partList.Add("strutCube");
+                partList.Add("strutOcto"); partList.Add("trussAdapter"); partList.Add("trussPiece1x"); partList.Add("trussPiece3x"); partList.Add("CircularIntake");
+                partList.Add("landingLeg1"); partList.Add("landingLeg1-2"); partList.Add("RCSBlock"); partList.Add("stackDecoupler"); partList.Add("airScoop");
+                partList.Add("commDish"); partList.Add("decoupler1-2"); partList.Add("dockingPort1"); partList.Add("dockingPort2"); partList.Add("dockingPort3");
+
+                partList.Add("dockingPortLarge"); partList.Add("dockingPortLateral"); partList.Add("fuelLine"); partList.Add("ladder1"); partList.Add("largeAdapter");
+                partList.Add("largeAdapter2"); partList.Add("launchClamp1"); partList.Add("linearRcs"); partList.Add("longAntenna"); partList.Add("miniLandingLeg");
+                partList.Add("parachuteDrogue"); partList.Add("parachuteLarge"); partList.Add("parachuteRadial"); partList.Add("parachuteSingle"); partList.Add("radialDecoupler");
+                partList.Add("radialDecoupler1-2"); partList.Add("radialDecoupler2"); partList.Add("ramAirIntake"); partList.Add("roverBody"); partList.Add("sensorAccelerometer");
+                partList.Add("sensorBarometer"); partList.Add("sensorGravimeter"); partList.Add("sensorThermometer"); partList.Add("spotLight1"); partList.Add("spotLight2");
+
+                partList.Add("stackBiCoupler"); partList.Add("stackDecouplerMini"); partList.Add("stackPoint1"); partList.Add("stackQuadCoupler"); partList.Add("stackSeparator");
+                partList.Add("stackSeparatorBig"); partList.Add("stackSeparatorMini"); partList.Add("stackTriCoupler"); partList.Add("telescopicLadder"); partList.Add("telescopicLadderBay");
+                partList.Add("SmallGearBay"); partList.Add("roverWheel1"); partList.Add("roverWheel2"); partList.Add("roverWheel3"); partList.Add("wheelMed"); partList.Add("flag");
+                partList.Add("kerbalEVA");
+
+                //0.22 parts
+                partList.Add("mediumDishAntenna"); partList.Add("GooExperiment"); partList.Add("science.module");
+
+                foreach(string part in partList) writer.WriteLine(part);
+        }
+        
+        private static void readModControl()
+        {
+            try
+            {	Log.Info("Reading {0}", MOD_CONTROL_FILE);
+            	kmpModControl = File.ReadAllBytes(MOD_CONTROL_FILE);
+            	Log.Info("Mod control reloaded.");
+            }
+            catch
+            {
+            	Log.Info(MOD_CONTROL_FILE + " not found, generating...");
+                TextWriter writer = File.CreateText(MOD_CONTROL_FILE);
+                writer.WriteLine("#You can comment by starting a line with a #, these are ignored by the server.");
+                writer.WriteLine("#Commenting will NOT work unless the line STARTS with a #.");
+                writer.WriteLine("#Sections supported are md5, partslist, resource-blacklist and resource-whitelist.");
+                writer.WriteLine("#You cannot use both resource-blacklist AND resource-whitelist in the same file.");
+                writer.WriteLine("#resource-blacklist bans ONLY the files you specify whereas resource-whitelist bans ALL resources except those you specify.");
+                writer.WriteLine("#Each section has its own type of formatting. Examples have been given.");
+                writer.WriteLine("#Sections are defined as follows");
+                writer.WriteLine();
+                writer.WriteLine("!required");
+                writer.WriteLine();
+                writer.WriteLine("#Here you can define GameData (mod) folders that the client requires before joining the server");
+                writer.WriteLine("#[Folder]");
+                writer.WriteLine("#Example: MechJeb2");
+                writer.WriteLine();
+                writer.WriteLine("Squad");
+                writer.WriteLine("#NOTE: This squad entry ensures that the client hasn't deleted the default parts. Disable this if undesired.");
+                writer.WriteLine();
+                writer.WriteLine("!md5");
+                writer.WriteLine();
+                writer.WriteLine("#To generate the md5 of a file you can use a utility such as this one: http://onlinemd5.com/");
+                writer.WriteLine("#For the MD5 section, file paths are read from inside GameData. If a client's MD5 does not match, they will not be permitted entry.");
+                writer.WriteLine("#You may not specify multiple MD5s for the same file. Do not put spaces around equals sign. Follow the example carefully.");
+                writer.WriteLine("#[File Path]=[MD5]");
+                writer.WriteLine("#Example: MechJeb2/Plugins/MechJeb2.dll=64E6E05C88F3466C63EDACD5CF8E5919");
+                writer.WriteLine();
+                writer.WriteLine("!resource-blacklist");
+                writer.WriteLine();
+                writer.WriteLine("#In this section you can specify the files to ban (or permit, if you change blacklist to whitelist).");
+                writer.WriteLine("#You do not need to specify a path, just a resource name.");
+                writer.WriteLine("#You can control any file from GameData here. It's prefered if you just specify the names of resources (as parts are controled by the partlist).");
+                writer.WriteLine("#[File]");
+                writer.WriteLine("#Example: MechJeb2.dll");
+                writer.WriteLine();
+                writer.WriteLine("!partslist");
+                writer.WriteLine();
+                writer.WriteLine("#This is a list of parts to allow users to put on their ships.");
+                writer.WriteLine("#If a part the client has doesn't appear on this list, they can still join the server but not use the part.");
+                writer.WriteLine("#The default stock parts have been added already for you.");
+                writer.WriteLine("#To add a mod part, add the name from the part's .cfg file. The name is the name from the PART{} section, where underscores are replaced with periods.");
+                writer.WriteLine("#[partname]");
+                writer.WriteLine("#Example: mumech.MJ2.Pod (NOTE: In the part.cfg this MechJeb2 pod is named mumech_MJ2_Pod. The _ have been replaced with .)");
+                writer.WriteLine("#You can use this application to generate partlists from a KSP installation if you want to add mod parts: http://forum.kerbalspaceprogram.com/threads/57284");
+                writer.WriteLine();
+                generatePartsList(writer);
+                writer.Close();
+                readModControl();
+            }
+        }
+        
         public void saveScreenshot(byte[] bytes, String player)
         {
             if (!Directory.Exists(SCREENSHOT_DIR))
@@ -290,7 +405,10 @@ namespace KMPServer
 
             //Start hosting server
             stopwatch.Start();
-
+			
+			//read info for server sided mod support
+			readModControl();
+			
             Log.Info("Hosting server on port {0} ...", settings.port);
 
             clients = new SynchronizedCollection<Client>(settings.maxClients);
@@ -432,6 +550,7 @@ namespace KMPServer
                     case "/countships": countShipsServerCommand(); break;
                     case "/listships": listShipsServerCommand(); break;
 					case "/deleteship": deleteShipServerCommand(parts); break;
+					case "/reloadmodfile": reloadModFileServerCommand(); break;
 					case "/say": sayServerCommand(rawParts); break;
 					case "/motd": motdServerCommand(rawParts); break;
 					case "/rules": rulesServerCommand(rawParts); break;
@@ -569,6 +688,11 @@ namespace KMPServer
 				Log.Info("Vessel ID invalid.");
             }
 
+        }
+        
+        private void reloadModFileServerCommand()
+        {
+        	readModControl();
         }
         
 		private void motdServerCommand(string[] parts)
@@ -2352,9 +2476,12 @@ namespace KMPServer
         {
             //Encode version string
             UnicodeEncoding encoder = new UnicodeEncoding();
+            
+
+
             byte[] version_bytes = encoder.GetBytes(KMPCommon.PROGRAM_VERSION);
 
-            byte[] data_bytes = new byte[version_bytes.Length + 12];
+            byte[] data_bytes = new byte[version_bytes.Length + 16 + kmpModControl.Length];
 
             //Write net protocol version
             KMPCommon.intToBytes(KMPCommon.NET_PROTOCOL_VERSION).CopyTo(data_bytes, 0);
@@ -2367,6 +2494,9 @@ namespace KMPServer
 
             //Write client ID
             KMPCommon.intToBytes(cl.clientIndex).CopyTo(data_bytes, 8 + version_bytes.Length);
+            
+            KMPCommon.intToBytes(kmpModControl.Length).CopyTo(data_bytes, 8 + version_bytes.Length + 4);
+            kmpModControl.CopyTo(data_bytes, 8 + version_bytes.Length + 4 + 4);
 
             cl.queueOutgoingMessage(KMPCommon.ServerMessageID.HANDSHAKE, data_bytes);
         }
@@ -2951,7 +3081,6 @@ namespace KMPServer
 
         private byte[] serverSettingBytes()
         {
-
             byte[] bytes = new byte[KMPCommon.SERVER_SETTINGS_LENGTH];
 
             KMPCommon.intToBytes(updateInterval).CopyTo(bytes, 0); //Update interval
@@ -2960,6 +3089,7 @@ namespace KMPServer
 			BitConverter.GetBytes(settings.safetyBubbleRadius).CopyTo(bytes,12); //Safety bubble radius
             bytes[20] = inactiveShipsPerClient; //Inactive ships per client
             bytes[21] = Convert.ToByte(settings.cheatsEnabled);
+
             return bytes;
         }
 
@@ -3406,6 +3536,7 @@ namespace KMPServer
 			Log.Info("/deleteship [ID] - Removes ship from universe."); 
             Log.Info("/dekessler <mins> - Remove debris that has not been updated for at least <mins> minutes (in-game time) (If no <mins> value is specified, debris that is older than 30 minutes will be cleared)");
             Log.Info("/save - Backup universe");
+            Log.Info("/reloadmodfile - Reloads the {0} file. Note that this will not recheck any currently logged in clients, only those joining", MOD_CONTROL_FILE);
 			Log.Info("/setinfo [info] - Updates the server info seen on master server list");
 			Log.Info("/motd [message] - Sets message of the day, leave blank for none");
 			Log.Info("/rules [rules] - Sets server rules, leave blank for none");


### PR DESCRIPTION
Server admins can now control clients mods. Features include MD5 checksumming (for version control), required mod list (mods that clients MUST have to join), resource control (whitelist or blacklist style) and the traditional partlist. Added server command /reloadmodfile so that admins can edit mods without restarting the server. Thanks to @godarklight for the networking assistance. Documentation in the form of comments is generated but I'll be writing a more detailed one and putting it somewhere. There's probably a few bugs in this but nothing that I can find, except a double disconnect which is low priority.
