### PR TITLE
offset changed for libpng hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,10 @@ WARNING FOR LINUX USERS: A bug with Unity/KSP as of 0.21.1 causes issues with se
   avoid using them as they often cause the game to crash without warning.
 
 Hex-editing your game binary remedies this issue as discussed on the forums here:
-http://forum.kerbalspaceprogram.com/threads/24529-The-Linux-compatibility-thread!?p=705281&viewfull=1#post705281
+http://forum.kerbalspaceprogram.com/threads/24529-The-Linux-compatibility-thread!?p=849510&viewfull=1#post849510
 
-  echo "7cebc7: 00" | xxd -r - KSP.x86\_64
-
-  echo "7cebcc: 00" | xxd -r - KSP.x86\_64
+  echo "838077: 00" | xxd -r - KSP.x86\_64
+  echo "83807c: 00" | xxd -r - KSP.x86\_64
 
 
 Warping & Relative Time


### PR DESCRIPTION
Updated readme to include updated libpng hack for linux users.

Background:
- KSP.x86_64 was rebuilt in version 0.23, but retains the erroneous static link to a 32-bit version of libpng.  Linux users will want to patch the binary as before, but at new offsets.
