### PR TITLE
Fix issue #496

### DIFF
--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -3165,7 +3165,13 @@ namespace KMP
 		
 		private void handleSyncTimeout()
 		{
-			if (!forceQuit && syncing && gameRunning) Invoke("finishSync",5f);
+			if (!forceQuit && syncing && gameRunning) {
+				disconnect("Sync Timeout");
+				KMPClientMain.sendConnectionEndMessage("Sync Timeout");
+				KMPClientMain.endSession = true;
+				forceQuit = true;
+				KMPClientMain.SetMessage("Disconnected: Sync timeout");
+			}
 		}
 		
 		private void finishSync()


### PR DESCRIPTION
Increasing the timeout does help somewhat, but only delays the issue. The game was getting told that is has finished syncing when it hasn't. I'm thinking something along these lines, probably not correct but it's pretty obvious to the player when a sync times out.
