### PR TITLE
Don't close pause menu during the initial sync. Fixes #494

### DIFF
--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -167,6 +167,7 @@ namespace KMP
 		private bool warping = false;
 		private bool syncing = false;
 		private bool docking = false;
+                private bool initialSync = false;
 		private float lastWarpRate = 1f;
 		private int chatMessagesWaiting = 0;
 		private Vessel lastEVAVessel = null;
@@ -3099,6 +3100,7 @@ namespace KMP
 				MapView.EnterMapView();
 				MapView.MapCamera.SetTarget("Kerbin");
 				StartCoroutine(sendSubspaceSyncRequest(-1,true));
+                                initialSync = true;
 				Invoke("handleSyncTimeout",300f);
 				docking = false;
 			}
@@ -3133,6 +3135,7 @@ namespace KMP
 		private void finishInGameSync()
 		{
 			syncing = false;
+			initialSync = false;
 			inGameSyncing = false;
 			showServerSync = false;
 		}
@@ -3190,7 +3193,7 @@ namespace KMP
 			{
 				if (!gameRunning) return;
 				
-				try { if (PauseMenu.isOpen && syncing) PauseMenu.Close(); } catch { }
+				try { if (PauseMenu.isOpen && syncing && !initialSync) PauseMenu.Close(); } catch { }
 				
 				if (FlightDriver.Pause) FlightDriver.SetPause(false);
 				if (KMPClientMain.cheatsEnabled == false) {


### PR DESCRIPTION
Tested during the inital sync, but cannot test during warp-syncs (Can't sync to the dev server because of shaped internet, and my own server syncs fast when it has no ships to send). It _should_ work.

It might also be an idea kicking the user back to the main menu screen if you're at the space center screen and initialSync == true.
