### PR TITLE
Don't close pause menu during the initial sync. Fixes #494

### DIFF
--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -167,6 +167,7 @@ namespace KMP
 		private bool warping = false;
 		private bool syncing = false;
 		private bool docking = false;
+		private bool initialSync = false;
 		private float lastWarpRate = 1f;
 		private int chatMessagesWaiting = 0;
 		private Vessel lastEVAVessel = null;
@@ -3125,6 +3126,7 @@ namespace KMP
 				MapView.EnterMapView();
 				MapView.MapCamera.SetTarget("Kerbin");
 				StartCoroutine(sendSubspaceSyncRequest(-1,true));
+				initialSync = true;
 				Invoke("handleSyncTimeout",300f);
 				docking = false;
 			}
@@ -3159,6 +3161,7 @@ namespace KMP
 		private void finishInGameSync()
 		{
 			syncing = false;
+			initialSync = false;
 			inGameSyncing = false;
 			showServerSync = false;
 		}
@@ -3216,7 +3219,7 @@ namespace KMP
 			{
 				if (!gameRunning) return;
 				
-				try { if (PauseMenu.isOpen && syncing) PauseMenu.Close(); } catch { }
+				try { if (PauseMenu.isOpen && syncing && !initialSync) PauseMenu.Close(); } catch { }
 				
 				if (FlightDriver.Pause) FlightDriver.SetPause(false);
 				if (KMPClientMain.cheatsEnabled == false) {


### PR DESCRIPTION
I tested this during the initial sync, Cannot test it during in-game warps due to shaping...

Hopefully this is the correct way to do this.
