### PR TITLE
Use a better format for writing dates so they sort correctly

### DIFF
--- a/KMPServer/Logger.cs
+++ b/KMPServer/Logger.cs
@@ -9,7 +9,7 @@ namespace KMPServer
     public static class Log
     {
         private static string LogFolder = "logs";
-        private static string LogFilename =  Path.Combine(LogFolder, "kmpserver " + DateTime.Now.ToString("dd-MM-yyyy HH-mm-ss") + ".log");
+        private static string LogFilename =  Path.Combine(LogFolder, "kmpserver " + DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss") + ".log");
         
         public enum LogLevels : int
         {


### PR DESCRIPTION
Looking at gartrals server logs is a mess due to the dd-MM-yyyy formatting.

Very much relevant: http://xkcd.com/1179/
