### PR TITLE
Fix issue #495.

### DIFF
--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -137,6 +137,7 @@ namespace KMP
 		private string newPort = "2076";
 		private string newFamiliar = "Server";
 		
+		private bool blockConnections = false;
 		private bool forceQuit = false;
 		private bool gameRunning = false;
 		private bool activeTermination = false;
@@ -684,6 +685,7 @@ namespace KMP
 		
 		public void disconnect(string message = "")
 		{
+			blockConnections = true;
 			if (HighLogic.LoadedSceneIsFlight || HighLogic.LoadedSceneIsEditor)
 			{
 				ScreenMessages.PostScreenMessage("You have been disconnected. Please return to the Main Menu to reconnect.",300f,ScreenMessageStyle.UPPER_CENTER);
@@ -3333,12 +3335,6 @@ namespace KMP
 		{
 			try
 			{
-				if (forceQuit)
-				{
-					forceQuit = false;
-					gameRunning = false;
-					HighLogic.LoadScene(GameScenes.MAINMENU);
-				}
 				if (!gameRunning) return;
 				
 				try { if (PauseMenu.isOpen && syncing) PauseMenu.Close(); } catch { }
@@ -3466,6 +3462,18 @@ namespace KMP
 
 		public void drawGUI()
 		{
+			if (blockConnections && !KMPClientMain.connectionThreadRunning)
+				blockConnections = false;
+
+			if (forceQuit)
+			{
+				Debug.Log("Force quit");
+				forceQuit = false;
+				gameRunning = false;
+				if (HighLogic.LoadedScene != GameScenes.MAINMENU)
+					HighLogic.LoadScene(GameScenes.MAINMENU);
+			}
+			
 			//Init info display options
 			if (KMPInfoDisplay.layoutOptions == null)
 				KMPInfoDisplay.layoutOptions = new GUILayoutOption[6];
@@ -3951,7 +3959,7 @@ namespace KMP
 				KMPClientMain.verifyShipsDirectory();
 				isVerified = true;
 			}
-			if (KMPClientMain.handshakeCompleted && KMPClientMain.tcpSocket != null)
+			if (KMPClientMain.handshakeCompleted && KMPClientMain.tcpSocket != null && !blockConnections)
 			{
 				if (KMPClientMain.tcpSocket.Connected && !gameRunning)
 				{


### PR DESCRIPTION
This took me _hours_. There are a few things going on here:
1. This bug happens before updateStep. It took me a while to figure that out.
2. The game is started from the drawGUI method. This also took me a while to figure out.
3. Setting forceQuit to true will set gameRunning to false.
4. This happens: https://github.com/TehGimp/KerbalMultiPlayer/blob/master/KMPManager.cs#L3956

Other bugs discovered:
The connection thread aborts itself which is _bad_ because the sockets never get cleaned up. I made the thread exit cleanly (I think) by changing the while loop and using an "exit" variable.

The easiest way to fix this was to block connections (well game starts) until the connection thread _cleanly_ exits.

EDIT: I had a merge conflict and brang forceQuit back into the GUI method where it was (I assume you did this because it didn't work? - Connection blocking should fix it)
