### PR TITLE
Various connection fixes

### DIFF
--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -3714,7 +3714,9 @@ namespace KMP
 					bool quit = GUILayout.Button("Quit",lockButtonStyle);
 					if (quit)
 					{
-						KMPClientMain.sendConnectionEndMessage("Requested quit during sync");
+						if (KMPClientMain.tcpSocket.Connected) {
+							KMPClientMain.sendConnectionEndMessage("Requested quit during sync");
+						}
 						KMPClientMain.endSession = true;
 						forceQuit = true;
 					}

--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -1462,6 +1462,7 @@ namespace KMPServer
                             //Acknowledge the client's message with a TCP message
                             client.queueOutgoingMessage(KMPCommon.ServerMessageID.UDP_ACKNOWLEDGE, null);
                             client.lastUDPACKTime = currentMillisecond;
+                            client.updateReceiveTimestamp();
                         }
 
                         //Handle the message


### PR DESCRIPTION
Fixes are as follows:
1. Don't spam UDP_PROBE messages when it sends through TCP.
2. Exit the interop loop on a connection lost. It threw lots of exceptions when I was disconnected. This probably only makes the debug log a little cleaner.
3. Allow the bailout button to work if the client is disconnected (It threw an exception with the sendConnectionEnd message)
4. UDP messages should update the client received timestamp. This should stop them being disconnected when the client is only sending UDP messages (The disconnect timer is 16 seconds and it's completely possible to send UDP only during a slow sync).
