### PR TITLE
Implement message splitting

### DIFF
--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -164,6 +164,10 @@ namespace KMP
         private static int receiveIndex = 0;
         private static int receiveHandleIndex = 0;
 
+        //Split message
+        private static int splitMessageReceiveIndex = 0;
+        private static byte[] splitMessageData;
+
         //Threading
 
         public static object tcpSendLock = new object();
@@ -529,8 +533,10 @@ namespace KMP
 
         public static void Connect()
         {
+            splitMessageData = null;
+            splitMessageReceiveIndex = 0;
             screenshotsWaiting.Clear();
-        	modFileChecked = false;
+            modFileChecked = false;
             clearConnectionState();
             File.Delete<KMPClientMain>("debug");
             serverThread = new Thread(beginConnect);
@@ -1072,8 +1078,36 @@ namespace KMP
                 case KMPCommon.ServerMessageID.SYNC_COMPLETE:
                     gameManager.HandleSyncCompleted();
                     break;
+                case KMPCommon.ServerMessageID.SPLIT_MESSAGE:
+		    handleSplitMessage(data);
+                    break;
             }
         }
+
+		public static void handleSplitMessage(byte[] data) {
+			if (splitMessageReceiveIndex == 0) {
+				//New split message
+				int split_message_length = KMPCommon.intFromBytes (data, 4);
+				splitMessageData = new byte[8 + split_message_length];
+				data.CopyTo (splitMessageData, 0);
+				splitMessageReceiveIndex = data.Length;
+			} else {
+				//Continued split message
+				data.CopyTo (splitMessageData, splitMessageReceiveIndex);
+				splitMessageReceiveIndex = splitMessageReceiveIndex + data.Length;
+			}
+				//Check if we have filled the byte array, if so, handle the message.
+			if (splitMessageReceiveIndex == splitMessageData.Length) {
+				//Parse the message and feed it into handleMessage
+				int joined_message_id = KMPCommon.intFromBytes (splitMessageData, 0);
+				int joined_message_length = KMPCommon.intFromBytes (splitMessageData, 4);
+				byte[] joined_message_data = new byte[joined_message_length];
+				Array.Copy (splitMessageData, 8, joined_message_data, 0, joined_message_length);
+				byte[] joined_message_data_decompressed = KMPCommon.Decompress(joined_message_data);
+				handleMessage ((KMPCommon.ServerMessageID)joined_message_id, joined_message_data_decompressed);
+				splitMessageReceiveIndex = 0;
+			}
+		}
 
         public static void clearConnectionState()
         {

--- a/KMPCommon.cs
+++ b/KMPCommon.cs
@@ -18,7 +18,7 @@ public class KMPCommon
     }
 
 	public const Int32 FILE_FORMAT_VERSION = 10000;
-	public const Int32 NET_PROTOCOL_VERSION = 10011;
+	public const Int32 NET_PROTOCOL_VERSION = 10012;
 	public const int MSG_HEADER_LENGTH = 8;
     public const int MAX_MESSAGE_SIZE = 1024 * 1024; //Enough room for a max-size craft file
 	public const int MESSAGE_COMPRESSION_THRESHOLD = 4096;
@@ -84,7 +84,8 @@ public class KMPCommon
 		ACTIVITY_UPDATE_IN_FLIGHT,
 		PING,
 		WARPING,
-		SSYNC
+		SSYNC,
+		SPLIT_MESSAGE /* Pre-emptive add for when message-queueing is implemented client side */
 	}
 
 	public enum ServerMessageID
@@ -105,7 +106,8 @@ public class KMPCommon
 		CRAFT_FILE /*Craft Type Byte : Craft name length : Craft Name : File bytes*/,
 		PING_REPLY,
 		SYNC /*tick*/,
-		SYNC_COMPLETE
+		SYNC_COMPLETE,
+		SPLIT_MESSAGE /* This allows higher priority messages more entry points into the send queue */
 	}
 
 	public enum ClientInteropMessageID


### PR DESCRIPTION
I'm unsure if we really want this, but I can see it being very helpful for users on slower connections.

This will split any messages taken out of the low priority queue into smaller pieces if it is bigger than SEND_BUFFER_SIZE (Perhaps I should rename that variable, it became unused when I implemented message queue sorting).

Pros:
High priority messages can get into the TCP stream in 8kb intervals. This means you only need to download 8kb until you can see someones chat message during a sync.

Cons:
There will be many more calls to asyncSend for big messages. This in theory will increase CPU load, but I don't think it will even be noticeable.
Larger overhead on TCP. I don't think we care about 20 bytes in for every 8kb though?

EDIT: This hasn't been tested completely, I was testing it with 100 byte splits, it rebuilt my ship from 237 parts pretty quickly. If you do like the idea of this it might be worth holding until 0.1.6 if we are still hoping for a release on new years.
