### PR TITLE
UDP now listens on the same ip and port as TCP

### DIFF
--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -435,15 +435,9 @@ namespace KMPServer
 
             try
             {
-                if (settings.hostIPv6 == true) {
-                    udpClient = new UdpClient(settings.port, AddressFamily.InterNetworkV6);
-                    udpClient.BeginReceive(asyncUDPReceive, null);
-                    //udpClient.Client.AllowNatTraversal(1);
-                } else {
-                    udpClient = new UdpClient(settings.port, AddressFamily.InterNetwork);
-                    udpClient.BeginReceive(asyncUDPReceive, null);
-                }
-                
+            	udpClient = new UdpClient((IPEndPoint)tcpListener.LocalEndpoint);
+                udpClient.BeginReceive(asyncUDPReceive, null);
+                //udpClient.Client.AllowNatTraversal(1);
             }
             catch
             {


### PR DESCRIPTION
While browsing the source I noticed that UDP was ignoring the ipBinding setting. The fix was to just use the TcpListener's localEndpoint. Also as an added bonus no need to check for IPv6 option.
