### PR TITLE
Updated monomake script to include mysql support

### DIFF
--- a/monomake
+++ b/monomake
@@ -23,6 +23,7 @@ mcs \
 -r:Assembly-CSharp-firstpass.dll \
 -r:UnityEngine.dll \
 -r:System.Data.SQLite.dll \
+-r:MySql.Data.dll \
 -r:KerbalMultiPlayer.dll \
 KMPServer/Properties/AssemblyInfo.cs \
 "KMPServer/Service References/ServerList/Reference.cs" \


### PR DESCRIPTION
Not sure if anyone was using it but the monomake script didn't have the MySql.Data.dll refernce.
