### PR TITLE
block ship control while typing in chat

### DIFF
--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -478,7 +478,10 @@ namespace KMP
 					else 
 					{
 						//Clear locks
-						InputLockManager.ClearControlLocks();
+						if (!KMPChatDX.showInput)
+						{
+							InputLockManager.ClearControlLocks();
+						}
 						unlockCrewGUI();
 					}
 					checkRemoteVesselIntegrity();
@@ -3381,7 +3384,11 @@ namespace KMP
 		    KMPScreenshotDisplay.windowEnabled = !KMPScreenshotDisplay.windowEnabled;
 
                 if (Input.GetKeyDown(KMPGlobalSettings.instance.chatTalkKey))
+                {
                     KMPChatDX.showInput = true;
+                    //DISABLE SHIP CONTROL
+                    InputLockManager.SetControlLock(ControlTypes.All,"KMP_ChatActive");
+                }
 
                 if (Input.GetKeyDown(KMPGlobalSettings.instance.chatHideKey) && isGameHUDHidden == false)
                 {
@@ -4448,6 +4455,8 @@ namespace KMP
                     enqueueChatOutMessage(KMPChatDX.chatEntryString);
                     KMPChatDX.chatEntryString = String.Empty;
                     KMPChatDX.showInput = false;
+                    //ENABLE SHIP CONTROL
+                    if (InputLockManager.GetControlLock("KMP_ChatActive") == (ControlTypes.All)) InputLockManager.RemoveControlLock("KMP_ChatActive");
                 }
 
                 if (GUI.GetNameOfFocusedControl() != "inputField")


### PR DESCRIPTION
I discovered this "bug" while launching and trying to chat at the same time. Might want to consider making this a optional feature. But I think the default should be to block the ship control while chatting.
