### PR TITLE
NTP style universe clock synchronisation.

### DIFF
--- a/KMPCommon.cs
+++ b/KMPCommon.cs
@@ -18,7 +18,7 @@ public class KMPCommon
     }
 
 	public const Int32 FILE_FORMAT_VERSION = 10000;
-	public const Int32 NET_PROTOCOL_VERSION = 10013;
+	public const Int32 NET_PROTOCOL_VERSION = 10014;
 	public const int MSG_HEADER_LENGTH = 8;
     public const int MAX_MESSAGE_SIZE = 1024 * 1024; //Enough room for a max-size craft file
 	public const int MESSAGE_COMPRESSION_THRESHOLD = 4096;
@@ -86,7 +86,8 @@ public class KMPCommon
 		PING,
 		WARPING,
 		SSYNC,
-		SPLIT_MESSAGE /* Pre-emptive add for when message-queueing is implemented client side */
+		SPLIT_MESSAGE, /* Pre-emptive add for when message-queueing is implemented client side */
+		SYNC_TIME /*NTP style sync*/
 	}
 
 	public enum ServerMessageID
@@ -108,7 +109,8 @@ public class KMPCommon
 		PING_REPLY,
 		SYNC /*tick*/,
 		SYNC_COMPLETE,
-		SPLIT_MESSAGE /* This allows higher priority messages more entry points into the send queue */
+		SPLIT_MESSAGE, /* This allows higher priority messages more entry points into the send queue */
+		SYNC_TIME /*NTP style sync*/
 	}
 
 	public enum ClientInteropMessageID
@@ -131,7 +133,8 @@ public class KMPCommon
 		SECONDARY_PLUGIN_UPDATE /*data*/,
 		SCENARIO_UPDATE /*data*/,
 		WARPING /*data*/,
-		SSYNC /*data*/
+		SSYNC /*data*/,
+		SYNC_TIME /*data*/
 	}
 	
 	

--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -161,6 +161,23 @@ namespace KMP
 		private float lastKeyPressTime = 0.0f;
 		private float lastFullProtovesselUpdate = 0.0f;
 		private float lastScenarioUpdateTime = 0.0f;
+		private float lastTimeSyncTime = 0.0f;
+		public float lastSubspaceLockChange = 0.0f;
+
+		//NTP-style time syncronize settings
+		private bool isSkewingTime = false;
+		private Int64 offsetSyncTick = 0; //The difference between the servers system clock and ours.
+		private List<Int64> listClientTimeSyncLatency = new List<Int64>(); //Holds old sync time messages so we can filter bad ones
+		private List<Int64> listClientTimeSyncOffset = new List<Int64>(); //Holds old sync time messages so we can filter bad ones
+		public List<float> listClientTimeWarp = new List<float>(); //Holds the average time skew so we can tell the server how badly we are lagging.
+		private int currentSyncTimeReceived = 0; //Number of TIME_SYNC's received
+		private bool isTimeSyncronized;
+		private const Int64 SYNC_TIME_OFFSET_FILTER = 500000; //50 milliseconds, If the new offset varies by more than 50 milliseconds the message is discarded.
+		private const Int64 SYNC_TIME_LATENCY_FILTER = 5000000; //500 milliseconds, Must receive reply within this time or the message is discarded
+		private const float SYNC_TIME_INTERVAL = 30f; //How often to sync time.
+		private const int SYNC_TIME_VALID_COUNT = 4; //Number of SYNC_TIME's to receive until time is valid.
+		private const int MAX_TIME_SYNC_HISTORY = 10; //The last 10 SYNC_TIME's are used for the offset filter.
+		private ScreenMessage skewMessage;
 
 		private Queue<KMPVesselUpdate> vesselUpdateQueue = new Queue<KMPVesselUpdate>();
 		private Queue<KMPVesselUpdate> newVesselUpdateQueue = new Queue<KMPVesselUpdate>();
@@ -218,6 +235,9 @@ namespace KMP
 		
 		public double lastTick = 0d;
 		public double targetTick = 0d;
+		public double skewTargetTick = 0;
+		public long skewServerTime = 0;
+		public float skewSubspaceSpeed = 1f;
 		
 		public Vector3d kscPosition = Vector3d.zero;
 		
@@ -454,60 +474,7 @@ namespace KMP
 					}
 				}
 
-				//Update universe time
-				try
-				{
-					double currentTick = Planetarium.GetUniversalTime();
-					if (isInFlight && targetTick > currentTick+0.05d)
-					{
-						Log.Debug("Syncing to new time " + targetTick + " from " + Planetarium.GetUniversalTime());
-						if (FlightGlobals.ActiveVessel.situation != Vessel.Situations.PRELAUNCH
-						    && FlightGlobals.ActiveVessel.situation != Vessel.Situations.LANDED
-						    && FlightGlobals.ActiveVessel.situation != Vessel.Situations.SPLASHED)
-						{
-							Vector3d oldObtVel = FlightGlobals.ActiveVessel.obt_velocity;
-							if (FlightGlobals.ActiveVessel.orbit.EndUT > 0)
-							{
-								double lastEndUT =  FlightGlobals.ActiveVessel.orbit.EndUT;
-								while (FlightGlobals.ActiveVessel.orbit.EndUT > 0
-								       && FlightGlobals.ActiveVessel.orbit.EndUT < targetTick
-								       && FlightGlobals.ActiveVessel.orbit.EndUT > lastEndUT
-								       && FlightGlobals.ActiveVessel.orbit.nextPatch != null)
-								{
-									Log.Debug("orbit EndUT < target: " + FlightGlobals.ActiveVessel.orbit.EndUT + " vs " + targetTick);
-									lastEndUT =  FlightGlobals.ActiveVessel.orbit.EndUT;
-									FlightGlobals.ActiveVessel.orbitDriver.orbit = FlightGlobals.ActiveVessel.orbit.nextPatch;
-									FlightGlobals.ActiveVessel.orbitDriver.UpdateOrbit();
-									if (FlightGlobals.ActiveVessel.orbit.referenceBody == null) FlightGlobals.ActiveVessel.orbit.referenceBody = FlightGlobals.Bodies.Find(b => b.name == "Sun");
-									Log.Debug("updated to next patch");
-								}
-							}
-							try
-				            {
-				                OrbitPhysicsManager.HoldVesselUnpack(1);
-				            }
-				            catch (NullReferenceException e)
-				            {
-                        Log.Debug("Exception thrown in updateStep(), catch 2, Exception: {0}", e.ToString());
-				            }
-							//Krakensbane shift to new orbital location
-							if (targetTick > currentTick+2.5d //if badly out of sync
-							    && !(FlightGlobals.ActiveVessel.orbit.referenceBody.atmosphere && FlightGlobals.ActiveVessel.orbit.altitude < FlightGlobals.ActiveVessel.orbit.referenceBody.maxAtmosphereAltitude)) //and not in atmo
-							{
-								Log.Debug("Krakensbane shift");
-								Vector3d diffPos = FlightGlobals.ActiveVessel.orbit.getPositionAtUT(targetTick) - FlightGlobals.ship_position;
-								foreach (Vessel otherVessel in FlightGlobals.Vessels.Where(v => v.packed == false && (v.id != FlightGlobals.ActiveVessel.id || (v.loaded && Vector3d.Distance(FlightGlobals.ship_position,v.GetWorldPos3D()) < INACTIVE_VESSEL_RANGE))))
-		                			otherVessel.GoOnRails();
-								getKrakensbane().setOffset(diffPos);
-								//Update velocity
-								FlightGlobals.ActiveVessel.ChangeWorldVelocity((-1 * oldObtVel) + FlightGlobals.ActiveVessel.orbitDriver.orbit.getOrbitalVelocityAtUT(targetTick).xzy);
-	            				FlightGlobals.ActiveVessel.orbitDriver.vel = FlightGlobals.ActiveVessel.orbit.vel;
-							}
-						}
-						Planetarium.SetUniversalTime(targetTick);
-						Log.Debug("sync completed");
-					}
-				} catch (Exception e) { Log.Debug("Exception thrown in updateStep(), catch 3, Exception: {0}", e.ToString()); Log.Debug("error during sync: " + e.Message + " " + e.StackTrace); }
+				krakensBaneWarp();
 
 				writeUpdates();
 				
@@ -585,7 +552,14 @@ namespace KMP
 				
 				foreach (String key in delete_list)
 					playerStatus.Remove(key);
-				
+
+				//Queue a time sync if needed
+				if (UnityEngine.Time.realtimeSinceStartup > lastTimeSyncTime + SYNC_TIME_INTERVAL) {
+					SyncTime();
+				}
+
+				//Do the Phys-warp NTP time sync dance.
+				SkewTime();
 				
 				//Prevent cases of remaining unfixed NREs from remote vessel updates from creating an inconsistent game state
 				if (HighLogic.fetch.log.Count > 500 && isInFlight && !syncing)
@@ -785,7 +759,7 @@ namespace KMP
 				if (String.IsNullOrEmpty(FlightGlobals.ActiveVessel.vesselName.Trim())) FlightGlobals.ActiveVessel.vesselName = "Unknown";
 				my_status.vesselName = FlightGlobals.ActiveVessel.vesselName;
 				my_status.lastUpdateTime = UnityEngine.Time.realtimeSinceStartup;
-				
+
 				if (playerStatus.ContainsKey(playerName))
 					playerStatus[playerName] = my_status;
 				else
@@ -3396,12 +3370,18 @@ namespace KMP
 				}
 				else
 				{
-					if (!warping) writePrimaryUpdate(); //Ensure server catches any vessel switch before warp
-					warping = true;
-					Log.Debug("warping");
+					if (!warping) {
+						skewServerTime = 0;
+						skewTargetTick = 0;
+						writePrimaryUpdate (); //Ensure server catches any vessel switch before warp
+						Log.Debug("warping");
+					}
+				warping = true;
 				}
-				Log.Debug("sending: " + TimeWarp.CurrentRate);
-				byte[] update_bytes = BitConverter.GetBytes(TimeWarp.CurrentRate);
+				Log.Debug("sending: " + TimeWarp.CurrentRate + ", " + Planetarium.GetUniversalTime());
+				byte[] update_bytes = new byte[12]; //warp rate float (4) + current tick double (8)
+				BitConverter.GetBytes(TimeWarp.CurrentRate).CopyTo(update_bytes, 0);
+				BitConverter.GetBytes(Planetarium.GetUniversalTime()).CopyTo(update_bytes, 4);
 				enqueuePluginInteropMessage(KMPCommon.PluginInteropMessageID.WARPING, update_bytes);
 			}
 		}
@@ -3445,6 +3425,7 @@ namespace KMP
 		
 		public void HandleSyncCompleted()
 		{
+			SyncTime();
 			if (!forceQuit && syncing && !inGameSyncing && gameRunning) Invoke("finishSync",5f);
 			else
 			{
@@ -3477,6 +3458,196 @@ namespace KMP
 				ScreenMessages.PostScreenMessage("Universe synchronized",1f,ScreenMessageStyle.UPPER_RIGHT);
 				StartCoroutine(returnToSpaceCenter());
 				//Disable debug logging once synced unless explicitly enabled
+			}
+		}
+
+		private void krakensBaneWarp(double krakensTick = 0) {
+			if (warping) return;
+		//Update universe time
+		if (krakensTick == 0) {
+			krakensTick = targetTick;
+		}
+		try
+		{
+			double currentTick = Planetarium.GetUniversalTime();
+			//Let SkewTime handle errors smaller than 5s.
+			if (isInFlight && krakensTick > currentTick+5d)
+			{
+				Log.Debug("Syncing to new time " + krakensTick + " from " + Planetarium.GetUniversalTime());
+				if (FlightGlobals.ActiveVessel.situation != Vessel.Situations.PRELAUNCH
+				    && FlightGlobals.ActiveVessel.situation != Vessel.Situations.LANDED
+				    && FlightGlobals.ActiveVessel.situation != Vessel.Situations.SPLASHED)
+				{
+					Vector3d oldObtVel = FlightGlobals.ActiveVessel.obt_velocity;
+					if (FlightGlobals.ActiveVessel.orbit.EndUT > 0)
+					{
+						double lastEndUT =  FlightGlobals.ActiveVessel.orbit.EndUT;
+						while (FlightGlobals.ActiveVessel.orbit.EndUT > 0
+						       && FlightGlobals.ActiveVessel.orbit.EndUT < krakensTick
+						       && FlightGlobals.ActiveVessel.orbit.EndUT > lastEndUT
+						       && FlightGlobals.ActiveVessel.orbit.nextPatch != null)
+						{
+							Log.Debug("orbit EndUT < target: " + FlightGlobals.ActiveVessel.orbit.EndUT + " vs " + krakensTick);
+							lastEndUT =  FlightGlobals.ActiveVessel.orbit.EndUT;
+							FlightGlobals.ActiveVessel.orbitDriver.orbit = FlightGlobals.ActiveVessel.orbit.nextPatch;
+							FlightGlobals.ActiveVessel.orbitDriver.UpdateOrbit();
+							if (FlightGlobals.ActiveVessel.orbit.referenceBody == null) FlightGlobals.ActiveVessel.orbit.referenceBody = FlightGlobals.Bodies.Find(b => b.name == "Sun");
+							Log.Debug("updated to next patch");
+						}
+					}
+					try
+					{
+						OrbitPhysicsManager.HoldVesselUnpack(1);
+					}
+					catch (NullReferenceException e)
+					{
+						Log.Debug("Exception thrown in updateStep(), catch 2, Exception: {0}", e.ToString());
+					}
+					//Krakensbane shift to new orbital location
+					if (krakensTick > currentTick+2.5d //if badly out of sync
+					    && !(FlightGlobals.ActiveVessel.orbit.referenceBody.atmosphere && FlightGlobals.ActiveVessel.orbit.altitude < FlightGlobals.ActiveVessel.orbit.referenceBody.maxAtmosphereAltitude)) //and not in atmo
+					{
+						Log.Debug("Krakensbane shift");
+						Vector3d diffPos = FlightGlobals.ActiveVessel.orbit.getPositionAtUT(krakensTick) - FlightGlobals.ship_position;
+						foreach (Vessel otherVessel in FlightGlobals.Vessels.Where(v => v.packed == false && (v.id != FlightGlobals.ActiveVessel.id || (v.loaded && Vector3d.Distance(FlightGlobals.ship_position,v.GetWorldPos3D()) < INACTIVE_VESSEL_RANGE))))
+							otherVessel.GoOnRails();
+						getKrakensbane().setOffset(diffPos);
+						//Update velocity
+						FlightGlobals.ActiveVessel.ChangeWorldVelocity((-1 * oldObtVel) + FlightGlobals.ActiveVessel.orbitDriver.orbit.getOrbitalVelocityAtUT(krakensTick).xzy);
+						FlightGlobals.ActiveVessel.orbitDriver.vel = FlightGlobals.ActiveVessel.orbit.vel;
+					}
+				}
+				Planetarium.SetUniversalTime(krakensTick);
+				Log.Debug("sync completed");
+			}
+		} catch (Exception e) { Log.Debug("Exception thrown in krakensBaneWarp(), catch 1, Exception: {0}", e.ToString()); Log.Debug("error during sync: " + e.Message + " " + e.StackTrace); }
+		}
+
+		private void SkewTime ()
+		{
+			if (syncing || warping) return;
+
+			if (HighLogic.LoadedScene == GameScenes.EDITOR || HighLogic.LoadedScene == GameScenes.SPH) return; //Time does not advance in the VAB or SPH
+
+			if (!isInFlightOrTracking && isSkewingTime) {
+				Log.Debug ("Stopping skew time");
+				isSkewingTime = false;
+				Time.timeScale = 1f;
+				return;
+			}
+
+
+			//This brings the computers MET timer in to line with the server.
+			if (isTimeSyncronized && skewServerTime != 0 && skewTargetTick != 0) {
+				long timeFromLastSync = (DateTime.UtcNow.Ticks + offsetSyncTick) - skewServerTime;
+				double timeFromLastSyncSeconds = (double)timeFromLastSync / 10000000;
+				double timeFromLastSyncSecondsAdjusted = timeFromLastSyncSeconds * skewSubspaceSpeed;
+				double currentError = Planetarium.GetUniversalTime () - (skewTargetTick + timeFromLastSyncSecondsAdjusted); //Ticks are integers of 100ns, Planetarium camera is a float in seconds.
+				double currentErrorMs = Math.Round (currentError * 1000, 2);
+				double currentErrorS = Math.Round (currentError, 2);
+
+				if (Math.Abs (currentError) > 5) {
+					skewMessage = ScreenMessages.PostScreenMessage ("Time skew fast, error: " + currentErrorS + " seconds.", 4f, ScreenMessageStyle.UPPER_RIGHT);
+					if (isInFlight) {
+						krakensBaneWarp(skewTargetTick + timeFromLastSyncSecondsAdjusted);
+					} else {
+						Planetarium.SetUniversalTime(skewTargetTick + timeFromLastSyncSeconds);
+					}
+					return;
+				}
+
+				//Dynamic warp.
+				float timeWarpRate = (float) Math.Pow(2, -currentError);
+				if ( timeWarpRate > 1.5f ) timeWarpRate = 1.5f;
+				if ( timeWarpRate < 0.5f ) timeWarpRate = 0.5f;
+
+				if (Math.Abs(currentError) > 0.2) {
+					isSkewingTime = true;
+					Time.timeScale = timeWarpRate;
+				}
+
+				if (Math.Abs(currentError) < 0.05 && isSkewingTime) {
+					isSkewingTime = false;
+					Time.timeScale = 1;
+				}
+
+				//Let's give the client a little bit of time to settle before being able to request a different rate.
+				if (UnityEngine.Time.realtimeSinceStartup > lastSubspaceLockChange + 10f) {
+					float requestedRate = (1 / timeWarpRate) * skewSubspaceSpeed;
+					listClientTimeWarp.Add(requestedRate);
+				} else {
+					listClientTimeWarp.Add(skewSubspaceSpeed);
+				}
+
+				//Keeps the last 10 seconds of warp history to report to the server
+				if (listClientTimeWarp.Count > 300) {
+					listClientTimeWarp.RemoveAt(0);
+				}
+
+
+				if (isSkewingTime) {
+					try {
+						skewMessage.duration = 0;
+					}
+					catch (Exception e) {
+						Log.Debug (e.ToString ());
+					}
+					skewMessage = ScreenMessages.PostScreenMessage("Time skew error: " + currentErrorMs + "ms.", 1f, ScreenMessageStyle.UPPER_RIGHT);
+				}
+			}
+		}
+
+		private void SyncTime()
+		{
+			//Have to write the actual time just before sending.
+			lastTimeSyncTime = UnityEngine.Time.realtimeSinceStartup;
+			enqueuePluginInteropMessage(KMPCommon.PluginInteropMessageID.SYNC_TIME, null);
+		}
+
+		public void HandleSyncTimeCompleted(byte[] data)
+		{
+			currentSyncTimeReceived = currentSyncTimeReceived + 1;
+			Int64 clientSend = BitConverter.ToInt64 (data, 0);
+			Int64 serverReceive = BitConverter.ToInt64 (data, 8);
+			Int64 serverSend = BitConverter.ToInt64 (data, 16);
+			Int64 clientReceive = DateTime.UtcNow.Ticks;
+			//Fancy NTP algorithm
+			Int64 clientLatency = (clientReceive - clientSend) - (serverSend - serverReceive);
+			Int64 clientOffset = ((serverReceive - clientSend) + (serverSend - clientReceive))/2;
+
+			//If time is synced, throw out outliers.
+			if (isTimeSyncronized) {
+				Int64 clientOffsetFilter = (Int64)listClientTimeSyncOffset.Average();
+				if (clientLatency < SYNC_TIME_LATENCY_FILTER && Math.Abs(clientOffset-clientOffsetFilter) < SYNC_TIME_OFFSET_FILTER) {
+					listClientTimeSyncOffset.Add (clientOffset);
+					listClientTimeSyncLatency.Add (clientLatency);
+				}
+			//If time is not synced, add all data (as there can be no outliers).
+			} else {
+				listClientTimeSyncOffset.Add(clientOffset);
+				listClientTimeSyncLatency.Add(clientLatency);
+				SyncTime();
+			}
+
+			//If received enough TIME_SYNC messages, set time to syncronized.
+			if (currentSyncTimeReceived >= SYNC_TIME_VALID_COUNT && !isTimeSyncronized) {
+				offsetSyncTick = (Int64)listClientTimeSyncOffset.Average();
+				Int64 latencySyncTick = (Int64)listClientTimeSyncLatency.Average();
+				isTimeSyncronized = true;
+				Log.Debug("Initial client time syncronized: " + (latencySyncTick/10000).ToString() + "ms latency, " + (offsetSyncTick/10000).ToString() + "ms offset");
+			}
+
+			if (listClientTimeSyncOffset.Count > MAX_TIME_SYNC_HISTORY) {
+				listClientTimeSyncOffset.RemoveAt(0);
+			}
+
+			if (listClientTimeSyncLatency.Count > MAX_TIME_SYNC_HISTORY) {
+				listClientTimeSyncLatency.RemoveAt(0);
+			}
+
+			//Update offset timer so the physwrap skew can use it
+			if (isTimeSyncronized) {
+				offsetSyncTick = (Int64)listClientTimeSyncOffset.Average();
 			}
 		}
 
@@ -4183,13 +4354,18 @@ namespace KMP
 					
 					serverVessels_RendezvousSmoothPos.Clear();
 					serverVessels_RendezvousSmoothVel.Clear();
+
+					isTimeSyncronized = false;
+					currentSyncTimeReceived = 0;
+					listClientTimeSyncLatency.Clear ();
+					listClientTimeSyncOffset.Clear ();
+					listClientTimeWarp.Clear ();
 	
 					newFlags.Clear();
 					
 					//Start MP game
 					KMPConnectionDisplay.windowEnabled = false;
 					gameRunning = true;
-					GameSettings.PHYSICS_FRAME_DT_LIMIT = 1.0f;
 					HighLogic.SaveFolder = "KMP";
 					HighLogic.CurrentGame = GamePersistence.LoadGame("start",HighLogic.SaveFolder,false,true);
 					HighLogic.CurrentGame.Parameters.Flight.CanAutoSave = false;
@@ -4209,7 +4385,7 @@ namespace KMP
 					GamePersistence.SaveGame("persistent",HighLogic.SaveFolder,SaveMode.OVERWRITE);
 					GameEvents.onFlightReady.Add(this.OnFirstFlightReady);
 					syncing = true;
-					
+
 					HighLogic.CurrentGame.Start();
 					
 					if (HasModule("ResearchAndDevelopment"))

--- a/KMPServer/Client.cs
+++ b/KMPServer/Client.cs
@@ -42,6 +42,8 @@ namespace KMPServer
 		public double syncOffset = 0.01d;
 		public int lagWarning = 0;
 		public bool warping = false;
+		public bool hasReceivedScenarioModules = false;
+		public float averageWarpRate = 1f;
 		
 		public bool receivedHandshake;
 
@@ -475,6 +477,7 @@ namespace KMPServer
 							}
 						}
 						isServerSendingData = true;
+						syncTimeRewrite(ref next_message);
 						tcpClient.GetStream().BeginWrite(next_message, 0, next_message.Length, asyncSend, next_message);
 					}
 				}
@@ -495,6 +498,20 @@ namespace KMPServer
             }
             catch (System.NullReferenceException) { }
 			
+		}
+
+		private void syncTimeRewrite(ref byte[] next_message) {
+			//SYNC_TIME Rewriting
+			int next_message_id = BitConverter.ToInt32(next_message, 0);
+			if (next_message_id == (int)KMPCommon.ServerMessageID.SYNC_TIME) {
+				byte[] next_message_stripped = new byte[next_message.Length - 8];
+				Array.Copy (next_message, 8, next_message_stripped, 0, next_message.Length - 8);
+				byte[] next_message_decompressed = KMPCommon.Decompress(next_message_stripped);
+				byte[] time_sync_rewrite = new byte[24];
+				next_message_decompressed.CopyTo(time_sync_rewrite, 0);
+				BitConverter.GetBytes(DateTime.UtcNow.Ticks).CopyTo(time_sync_rewrite, 16);
+				next_message = Server.buildMessageArray(KMPCommon.ServerMessageID.SYNC_TIME, time_sync_rewrite);
+			}
 		}
 
 		public void splitOutgoingMessage(ref byte[] next_message)

--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -103,6 +103,10 @@ namespace KMPServer
 
         private bool backedUpSinceEmpty = false;
         private Dictionary<Guid, long> recentlyDestroyed = new Dictionary<Guid, long>();
+		private Dictionary<int, double> subSpaceMasterTick = new Dictionary<int, double>();
+		private Dictionary<int, long> subSpaceMasterTime = new Dictionary<int, long>();
+		private Dictionary<int, float> subSpaceMasterSpeed = new Dictionary<int, float>();
+		private Dictionary<int, long> subSpaceLastRateCheck = new Dictionary<int, long>();
 
 		private Boolean bHandleCommandsRunning = true;
 		
@@ -1910,8 +1914,8 @@ namespace KMPServer
             clientMessageQueue.Enqueue(message);
         }
 
-        private KMPCommon.ClientMessageID[] AllowNullDataMessages = { KMPCommon.ClientMessageID.SCREEN_WATCH_PLAYER, KMPCommon.ClientMessageID.CONNECTION_END, KMPCommon.ClientMessageID.ACTIVITY_UPDATE_IN_FLIGHT, KMPCommon.ClientMessageID.ACTIVITY_UPDATE_IN_GAME, KMPCommon.ClientMessageID.PING };
-        private KMPCommon.ClientMessageID[] AllowClientNotReadyMessages = { KMPCommon.ClientMessageID.HANDSHAKE, KMPCommon.ClientMessageID.TEXT_MESSAGE, KMPCommon.ClientMessageID.SCREENSHOT_SHARE, KMPCommon.ClientMessageID.CONNECTION_END, KMPCommon.ClientMessageID.ACTIVITY_UPDATE_IN_FLIGHT, KMPCommon.ClientMessageID.ACTIVITY_UPDATE_IN_GAME, KMPCommon.ClientMessageID.PING, KMPCommon.ClientMessageID.UDP_PROBE, KMPCommon.ClientMessageID.WARPING, KMPCommon.ClientMessageID.SSYNC };
+        private KMPCommon.ClientMessageID[] AllowNullDataMessages = { KMPCommon.ClientMessageID.SCREEN_WATCH_PLAYER, KMPCommon.ClientMessageID.CONNECTION_END, KMPCommon.ClientMessageID.ACTIVITY_UPDATE_IN_FLIGHT, KMPCommon.ClientMessageID.ACTIVITY_UPDATE_IN_GAME, KMPCommon.ClientMessageID.PING, KMPCommon.ClientMessageID.SYNC_TIME };
+        private KMPCommon.ClientMessageID[] AllowClientNotReadyMessages = { KMPCommon.ClientMessageID.HANDSHAKE, KMPCommon.ClientMessageID.TEXT_MESSAGE, KMPCommon.ClientMessageID.SCREENSHOT_SHARE, KMPCommon.ClientMessageID.CONNECTION_END, KMPCommon.ClientMessageID.ACTIVITY_UPDATE_IN_FLIGHT, KMPCommon.ClientMessageID.ACTIVITY_UPDATE_IN_GAME, KMPCommon.ClientMessageID.PING, KMPCommon.ClientMessageID.UDP_PROBE, KMPCommon.ClientMessageID.WARPING, KMPCommon.ClientMessageID.SSYNC, KMPCommon.ClientMessageID.SYNC_TIME };
 
         public void handleMessage(Client cl, KMPCommon.ClientMessageID id, byte[] data)
         {
@@ -1974,6 +1978,9 @@ namespace KMPServer
 	                    case KMPCommon.ClientMessageID.SSYNC:
 	                        HandleSSync(cl, data);
 	                        break;
+						case KMPCommon.ClientMessageID.SYNC_TIME:
+							HandleTimeSync(cl, data);
+							break;
 	                }
 	            }
 	            catch (NullReferenceException)
@@ -2016,9 +2023,21 @@ namespace KMPServer
             sendSubspace(cl, true);
         }
 
+		private void HandleTimeSync(Client cl, byte[] data)
+		{
+			//Message format: clientsendtick(8), serverreceivetick(8), serversendtick(8). The server send tick gets added during actual sending.
+			byte[] newdata = new byte[16];
+			data.CopyTo (newdata, 0);
+			BitConverter.GetBytes(DateTime.UtcNow.Ticks).CopyTo(newdata, 8);
+			byte[] message_bytes = buildMessageArray(KMPCommon.ServerMessageID.SYNC_TIME, newdata);
+			cl.queueOutgoingMessage(message_bytes); //This is still re-written during the actual send.
+			Log.Debug("{0} time sync request", cl.username);
+		}
+
         private void HandleWarping(Client cl, byte[] data)
         {
             float rate = BitConverter.ToSingle(data, 0);
+			double newsubspacetick = BitConverter.ToDouble(data, 4);
             if (cl.warping)
             {
                 if (rate < 1.1f)
@@ -2055,8 +2074,12 @@ namespace KMPServer
                     }
 					if (settings.useMySQL) universeDB.Close();
                     cl.currentSubspaceID = newSubspace;
+					Log.Debug("Adding new time sync data for subspace {0}", newSubspace);
+					subSpaceMasterTick.Add(cl.currentSubspaceID, newsubspacetick);
+					subSpaceMasterTime.Add(cl.currentSubspaceID, DateTime.UtcNow.Ticks);
+					subSpaceMasterSpeed.Add(cl.currentSubspaceID, 1f);
 					cl.warping = false;
-                    sendSubspace(cl, true, false);
+                    sendSubspace(cl, true, true);
 					cl.lastTick = -1d;
                     Log.Activity("{0} set to new subspace {1}", cl.username, newSubspace);
                 }
@@ -2077,7 +2100,7 @@ namespace KMPServer
             double incomingTick = BitConverter.ToDouble(data, 0);
             double lastSubspaceTick = incomingTick;
 
-            cl.lastTick = incomingTick;
+			cl.lastTick = incomingTick;
             if (!cl.warping)
             {
 				var universeDB = KMPServer.Server.universeDB;
@@ -2104,30 +2127,6 @@ namespace KMPServer
                     cmd.Dispose();
                 }
 				if (settings.useMySQL) universeDB.Close();
-                if (lastSubspaceTick - incomingTick > 0.2d)
-                {
-                    cl.syncOffset += 0.001d;
-                    if (cl.syncOffset > 0.5d) cl.syncOffset = 0.5;
-                    if (cl.receivedHandshake && cl.lastSyncTime < (currentMillisecond - 2500L))
-                    {
-                        Log.Debug("Sending time-sync to {0} current offset {1}", cl.username, cl.syncOffset);
-                        if (cl.lagWarning > 24)
-                        {
-                            cl.lastSyncTime = currentMillisecond;
-                            markClientForDisconnect(cl, "Your game was running too slowly compared to other players. Please try reconnecting in a moment.");
-                        }
-                        else
-                        {
-                            sendSyncMessage(cl, lastSubspaceTick + cl.syncOffset);
-                            cl.lastSyncTime = currentMillisecond;
-                            cl.lagWarning++;
-                        }
-                    }
-                }
-                else
-                {
-                    cl.lagWarning = 0;
-                    if (cl.syncOffset > 0.01d) cl.syncOffset -= 0.001d;
 					var universeDB2 = universeDB;
 					if (settings.useMySQL) {
 						universeDB2 = new MySqlConnection(settings.mySQLConnString);
@@ -2142,8 +2141,9 @@ namespace KMPServer
                     cmd.Dispose();
 					if (settings.useMySQL) universeDB.Close();
                     if (lastSubspaceTick > 100d) sendHistoricalVesselUpdates(cl.currentSubspaceID, incomingTick, lastSubspaceTick);
-                }
-            }
+					cl.averageWarpRate = BitConverter.ToSingle(data, 8);
+					processClientAverageWarpRates(cl.currentSubspaceID);
+			}
         }
 
         private void HandleActivityUpdateInGame(Client cl)
@@ -3211,8 +3211,8 @@ namespace KMPServer
                                 sendVesselStatusUpdateToAll(cl, cl.currentVessel);
                             }
 
-                            cl.currentVessel = vessel_update.kmpID;
-                        }
+							cl.currentVessel = vessel_update.kmpID;
+						}
 
                         //Store update
                         storeVesselUpdate(data, cl, vessel_update.kmpID, vessel_update.tick);
@@ -3515,6 +3515,8 @@ namespace KMPServer
 		
 		private void sendScenarios(Client cl)
 		{
+			if (cl.hasReceivedScenarioModules) return;
+			cl.hasReceivedScenarioModules = true;
 			var universeDB = KMPServer.Server.universeDB;
 			if (settings.useMySQL) {
 				universeDB = new MySqlConnection(settings.mySQLConnString);
@@ -3546,10 +3548,71 @@ namespace KMPServer
 		
         private void sendSyncMessage(Client cl, double tick)
         {
+			double subspaceTick = tick;
+			float subspaceSpeed = 1f;
+			long subspaceTime = DateTime.UtcNow.Ticks;
+			if (subSpaceMasterTick.ContainsKey(cl.currentSubspaceID)) {
+				double tickOffset = (double) (subspaceTime - subSpaceMasterTime[cl.currentSubspaceID]) / 10000000; //The magic number that converts 100ns to seconds.
+				subspaceTick = subSpaceMasterTick[cl.currentSubspaceID] + tickOffset;
+				subspaceSpeed = subSpaceMasterSpeed[cl.currentSubspaceID];
+				Log.Debug ("Found entry: " + tickOffset + " offset for subspace " + cl.currentSubspaceID);
+			} else {
+				subSpaceMasterTick.Add(cl.currentSubspaceID, subspaceTick);
+				subSpaceMasterTime.Add(cl.currentSubspaceID, subspaceTime);
+				subSpaceMasterSpeed.Add(cl.currentSubspaceID, 1f);
+				Log.Debug ("Added entry for subspace " + cl.currentSubspaceID);
+			}
             //Log.Info("Time sync for: " + cl.username);
-            byte[] message_bytes = buildMessageArray(KMPCommon.ServerMessageID.SYNC, BitConverter.GetBytes(tick));
+			byte[] timesyncdata = new byte[20]; //double (8) subspace Tick, long (8) server time, float (4) subspace speed.
+			BitConverter.GetBytes(subspaceTick).CopyTo(timesyncdata, 0);
+			BitConverter.GetBytes(subspaceTime).CopyTo(timesyncdata, 8);
+			BitConverter.GetBytes(subspaceSpeed).CopyTo(timesyncdata, 16);
+            byte[] message_bytes = buildMessageArray(KMPCommon.ServerMessageID.SYNC, timesyncdata);
             cl.queueOutgoingMessage(message_bytes);
         }
+
+		private void sendSyncMessageToSubspace(int subspaceID) {
+			foreach (Client cl in clients) {
+				if (cl.currentSubspaceID == subspaceID) {
+					sendSyncMessage (cl, subSpaceMasterTick[subspaceID]); //The tick is skewed correctly in sendSyncMessage.
+				}
+			}
+		}
+
+		private void processClientAverageWarpRates(int subspaceID) {
+
+			if (subSpaceLastRateCheck.ContainsKey(subspaceID)) {
+				if (currentMillisecond < subSpaceLastRateCheck[subspaceID] + 30000) return; //Only check once every 30 seconds per subspace.
+			}
+			subSpaceLastRateCheck [subspaceID] = currentMillisecond;
+
+			if (!subSpaceMasterSpeed.ContainsKey(subspaceID) || !subSpaceMasterTick.ContainsKey(subspaceID) || !subSpaceMasterSpeed.ContainsKey(subspaceID)) return; //Only works for locked subspaces
+
+			int numberOfClientsInSubspace = 0;
+			float subspaceWarpRateTotal = 0f;
+			float subspaceMinWarpRate = 1f;
+			foreach (Client cl in clients) {
+				if (cl.currentSubspaceID == subspaceID) {
+					numberOfClientsInSubspace++;
+					subspaceWarpRateTotal += cl.averageWarpRate;
+					if (cl.averageWarpRate < subspaceMinWarpRate) subspaceMinWarpRate = cl.averageWarpRate;
+				}
+			}
+			float subspaceAverageWarpRate = subspaceWarpRateTotal / numberOfClientsInSubspace; //Aka: The average warp rate of the subspace.
+			float subspaceTargetRate = (subspaceAverageWarpRate + subspaceMinWarpRate) / 2; //Lets slow down to halfway between the average and slowest player.
+			if (subspaceTargetRate > 1f) subspaceTargetRate = 1f; //Let's just not worry about rates above 0.95 times normal.
+			if (subspaceTargetRate < 0.75f) subspaceTargetRate = 0.75f; //Let's set a lower bound to something still reasonable like 0.75f.
+			float subspaceDiffRate = Math.Abs(subSpaceMasterSpeed [subspaceID] - subspaceTargetRate);
+			if (subspaceDiffRate > 0.05f) { //Allow 3% tolerance
+				Log.Debug ("Subspace " + subspaceID + " relocked to " + subspaceTargetRate + "x speed.");
+				long currenttime = DateTime.UtcNow.Ticks;
+				double tickOffset = (double) (currenttime - subSpaceMasterTime[subspaceID]) / 10000000; //The magic number that converts 100ns to seconds.
+				subSpaceMasterTick[subspaceID] = subSpaceMasterTick[subspaceID] + tickOffset;
+				subSpaceMasterTime[subspaceID] = currenttime;
+				subSpaceMasterSpeed[subspaceID] = subspaceTargetRate;
+				sendSyncMessageToSubspace (subspaceID);
+			}
+		}
 		
         private void sendSyncCompleteMessage(Client cl)
         {


### PR DESCRIPTION
This is getting very close, Everyone is kept in sync (apart from warping players) to some insanely small time difference.

I've dropped setting the frame dt limit override, I'm not sure why it was set to one second, but if it was to do with timing, well this fixes it :)

We should consider removing the "kicked for too slow" messages if we trust NTP sync.

We should possibly wipe the server time entries if players aren't in the subspace (because that would keep the server time "simulating with no players in the background").

EDIT: And I should probably gracefully handle a system clock change
