### PR TITLE
Use KSPAddon attribute instead of unit test bootstrap

### DIFF
--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -10,17 +10,6 @@ using System.Threading;
 namespace KMP
 {
 
-    public class Bootstrap : KSP.Testing.UnitTest {
-        public Bootstrap() {
-			if (KMPManager.GameObjectInstance == null)
-			{
-				Log.Info("*** KMP version " + KMPCommon.PROGRAM_VERSION + " started");
-				KMPManager.GameObjectInstance = new GameObject("KMPManager", typeof(KMPManager));
-				UnityEngine.Object.DontDestroyOnLoad(KMPManager.GameObjectInstance);
-			}
-        }
-    }
-
     public class LoadedFileInfo
     {
         /// <summary>
@@ -64,6 +53,7 @@ namespace KMP
         }
     }
 	
+	[KSPAddon(KSPAddon.Startup.Instantly, true)]
 	public class KMPManager : MonoBehaviour
 	{
 		
@@ -3186,7 +3176,7 @@ namespace KMP
 
 		public void Awake()
 		{
-			DontDestroyOnLoad(this);
+			DontDestroyOnLoad(this.gameObject);
 			CancelInvoke();
 			InvokeRepeating("updateStep", 1/30.0f, 1/30.0f);
 			loadGlobalSettings();


### PR DESCRIPTION
The "Run Unit Test" in the lower left part of the screen is a little odd. Using KSPs KSPAddon attribute and telling to game to load the plugin instead of using a unit test just seems like the right way to go about loading the plugin.

The down side is the plugin doesn't get loaded till the game gets to the main menu. It doesn't cause any problems but it moves the "Hang" from hashing the game data folder from the initial start of the game to the loading screen just before the main menu.
