### PR TITLE
Fix #647

### DIFF
--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -2393,11 +2393,11 @@ namespace KMP
 								splitOutgoingMessage(ref next_message);
 							}
 						}
-						isClientSendingData = true;
 						if (next_message != null) {
+							isClientSendingData = true;
 							syncTimeRewrite(ref next_message);
+							tcpClient.GetStream().BeginWrite(next_message, 0, next_message.Length, new AsyncCallback(asyncTCPSend), next_message);
 						}
-						tcpClient.GetStream().BeginWrite(next_message, 0, next_message.Length, new AsyncCallback(asyncTCPSend), next_message);
 					}
 				}
 			}


### PR DESCRIPTION
I'm unsure how we are getting null objects in the queue for #647, but next_message.length is the one probably throwing the error (because null's don't have a length, unlike byte[0]).
