### PR TITLE
Allow krakensbane to shift back in time, rely on NTP sync for setting th...

### DIFF
--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -1058,7 +1058,6 @@ namespace KMP
 
 				case KMPCommon.ServerMessageID.SYNC:
 					if (data != null) {
-						gameManager.targetTick = BitConverter.ToDouble (data, 0) + Convert.ToDouble (lastPing);
 						gameManager.skewTargetTick = BitConverter.ToDouble (data, 0);
 						gameManager.skewServerTime = BitConverter.ToInt64 (data, 8);
 						gameManager.skewSubspaceSpeed = BitConverter.ToSingle (data, 16);

--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -268,7 +268,6 @@ namespace KMP
 		private Krakensbane krakensbane;
 		
 		public double lastTick = 0d;
-		public double targetTick = 0d;
 		public double skewTargetTick = 0;
 		public long skewServerTime = 0;
 		public float skewSubspaceSpeed = 1f;
@@ -507,8 +506,6 @@ namespace KMP
 						checkVesselPrivacy(possible_target);
 					}
 				}
-
-				krakensBaneWarp();
 
 				writeUpdates();
 				
@@ -3505,15 +3502,11 @@ namespace KMP
 
 		private void krakensBaneWarp(double krakensTick = 0) {
 			if (warping) return;
-		//Update universe time
-		if (krakensTick == 0) {
-			krakensTick = targetTick;
-		}
 		try
 		{
 			double currentTick = Planetarium.GetUniversalTime();
 			//Let SkewTime handle errors smaller than 5s.
-			if (isInFlight && krakensTick > currentTick+5d)
+			if (isInFlight && Math.Abs(krakensTick - currentTick) > 5d)
 			{
 				Log.Debug("Syncing to new time " + krakensTick + " from " + Planetarium.GetUniversalTime());
 				if (FlightGlobals.ActiveVessel.situation != Vessel.Situations.PRELAUNCH
@@ -3546,7 +3539,7 @@ namespace KMP
 						Log.Debug("Exception thrown in updateStep(), catch 2, Exception: {0}", e.ToString());
 					}
 					//Krakensbane shift to new orbital location
-					if (krakensTick > currentTick+2.5d //if badly out of sync
+					if (Math.Abs(krakensTick - currentTick) > 2.5d //if badly out of sync
 					    && !(FlightGlobals.ActiveVessel.orbit.referenceBody.atmosphere && FlightGlobals.ActiveVessel.orbit.altitude < FlightGlobals.ActiveVessel.orbit.referenceBody.maxAtmosphereAltitude)) //and not in atmo
 					{
 						Log.Debug("Krakensbane shift");
@@ -3593,7 +3586,7 @@ namespace KMP
 					if (isInFlight) {
 						krakensBaneWarp(skewTargetTick + timeFromLastSyncSecondsAdjusted);
 					} else {
-						Planetarium.SetUniversalTime(skewTargetTick + timeFromLastSyncSeconds);
+						Planetarium.SetUniversalTime(skewTargetTick + timeFromLastSyncSecondsAdjusted);
 					}
 					return;
 				}

--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -3619,11 +3619,11 @@ namespace KMPServer
 			if (subspaceTargetRate > 1f) subspaceTargetRate = 1f; //Let's just not worry about rates above 0.95 times normal.
 			if (subspaceTargetRate < 0.75f) subspaceTargetRate = 0.75f; //Let's set a lower bound to something still reasonable like 0.75f.
 			float subspaceDiffRate = Math.Abs(subSpaceMasterSpeed [subspaceID] - subspaceTargetRate);
-			if (subspaceDiffRate > 0.05f) { //Allow 3% tolerance
+			if (subspaceDiffRate > 0.03f) { //Allow 3% tolerance
 				Log.Debug ("Subspace " + subspaceID + " relocked to " + subspaceTargetRate + "x speed.");
 				long currenttime = DateTime.UtcNow.Ticks;
 				double tickOffset = (double) (currenttime - subSpaceMasterTime[subspaceID]) / 10000000; //The magic number that converts 100ns to seconds.
-				subSpaceMasterTick[subspaceID] = subSpaceMasterTick[subspaceID] + tickOffset;
+				subSpaceMasterTick[subspaceID] = subSpaceMasterTick[subspaceID] + (tickOffset * subSpaceMasterSpeed [subspaceID]);
 				subSpaceMasterTime[subspaceID] = currenttime;
 				subSpaceMasterSpeed[subspaceID] = subspaceTargetRate;
 				sendSyncMessageToSubspace (subspaceID);


### PR DESCRIPTION
...e time, set the correct time when not in warp.

Krakensbane and ntp-sync were fighting, constantly resetting the time to what they think was correct. As ntp-sync allows for slow running subspaces and it seems reliable I've demoted krakensbane to only be used from within skewtime.

I'm unaware of any consequences, but I've allowed krakensbane to go back in time too.

Also fixed a logic error where skewtime fast would set the time according to a 1x speed running subspace and not an adjusted subspace.

EDIT: Also fixed another logic error where the slowed subspace would tick forward at 1x on a relock instead of taking the subspace rate into account. Very similar to the above logic error.
