### PR TITLE
Fix mod control.

### DIFF
--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -281,210 +281,253 @@ namespace KMP
         
         private static void parseModFile(string ModFileContent)
         {
-            System.IO.StringReader reader = new System.IO.StringReader(ModFileContent);
-        	
-	        string resourcemode = "whitelist";
-	        List<string> allowedParts = new List<string>();
-            Dictionary<string, SHAMod> hashes = new Dictionary<string, SHAMod>();
-	        List<string> resources = new List<string>();
-	        List<string> modList = new List<string>();
-	        string line;
-	        string[] splitline;
-	        string readmode = "";
-	        while (true)
-	        {
-	        	line = reader.ReadLine();
-                if (line == null)
+            using (System.IO.StringReader reader = new System.IO.StringReader(ModFileContent))
+            {
+                string resourcemode = "whitelist";
+                List<string> allowedParts = new List<string>();
+                Dictionary<string, SHAMod> hashes = new Dictionary<string, SHAMod>();
+                List<string> resources = new List<string>();
+                List<string> modList = new List<string>();
+                string line;
+                string[] splitline = new string[2];
+                string readmode = "";
+                while (true)
                 {
-                    break;
-                }
-	        	try
-	        	{
-				    if(!String.IsNullOrEmpty(line))
-				    {
-					    if(line[0] != '#')//allows commented lines
-					    {
-						    if(line[0] == '!')//changing readmode
-						    {
-							    if(line.Contains("partslist")){
-								    readmode = "parts";
-							    }
-                                else if (line.Contains("required-files"))
+                    line = reader.ReadLine(); //Trim off any whitespace from the start or end. This would allow indenting of the mod file.
+                    if (line == null)
+                    {
+                        break;
+                    }
+                    line = line.Trim();
+                    try
+                    {
+                        if (!String.IsNullOrEmpty(line) && line[0] != '#') //Skip empty or commented lines.
+                        { 
+                            if (line[0] == '!') //changing readmode
+                            { 
+                                string trimmedLine = line.Substring(1); //Returns 'partslist' from ' !partslist'
+                                switch (trimmedLine)
                                 {
-                                    readmode = "required-files";
-							    }
-                                else if (line.Contains("optional-files"))
-                                {
-                                    readmode = "optional-files";
+                                    case "partslist":
+                                    case "required-files":
+                                    case "optional-files":
+                                        readmode = trimmedLine;
+                                        break;
+                                    case "resource-blacklist": //allow all resources EXCEPT these in file
+                                        readmode = "resource";
+                                        resourcemode = "blacklist";
+                                        break;
+                                    case "resource-whitelist": //allow NO resources EXCEPT these in file
+                                        readmode = "resource";
+                                        resourcemode = "whitelist";
+                                        break;
                                 }
-							    else if(line.Contains("resource-blacklist")){ //allow all resources EXCEPT these in file
-								    readmode = "resource";
-								    resourcemode = "blacklist";
-							    }
-							    else if(line.Contains("resource-whitelist")){ //allow NO resources EXCEPT these in file
-								    readmode = "resource";
-								    resourcemode = "whitelist";
-							    }
-							    else if(line.Contains("required")){
-								    readmode = "required";
-							    }
-						    }
-						    else if(readmode == "parts")
-						    {
-							    allowedParts.Add(line);
-						    }
-                            else if (readmode == "required-files")
-						    {
-                                splitline = line.Split('=');
-                                string hash = "";
-                                if (splitline.Length > 1)
-                                {
-                                    hash = splitline[1];
-                                }
-                                hashes.Add(splitline[0], new SHAMod { sha = hash, required = true });
-						    }
-                            else if (readmode == "optional-files")
-                            {
-                                splitline = line.Split('=');
-                                string hash = "";
-                                if (splitline.Length > 1)
-                                {
-                                    hash = splitline[1];
-                                }
-                                hashes.Add(splitline[0], new SHAMod { sha = hash, required = false });
                             }
-						    else if(readmode == "resource"){
-							    resources.Add(line);
-						    }
-						    else if(readmode == "required"){
-							    modList.Add(line);
-						    }
-					    }
-				    }
-			    }
-		        catch (Exception e)
-		        {
-		            Log.Info(e.ToString());
-		        }
-	        }
-	        
-	        reader.Close();
-	        partList = allowedParts; //make all the vars global once we're done parsing
-            modFileList = hashes;
-	        resourceControlMode = resourcemode;
-	        resourceList = resources;
-	        requiredModList = modList;
+                            else
+                            {
+                                if (readmode == "partslist")
+                                {
+                                    allowedParts.Add(line);
+                                }
+                                if (readmode == "required-files")
+                                {
+                                    string hash = "";
+                                    splitline[0] = line;
+                                    if (line.Contains('=')) //Let's make the = on the end of the lines optional
+                                    {
+                                        splitline = line.Split('=');
+                                        if (splitline.Length > 1)
+                                        {
+                                            hash = splitline[1];
+                                        }
+                                    }
+                                    hashes.Add(splitline[0], new SHAMod { sha = hash, required = true });
+                                }
+                                if (readmode == "optional-files")
+                                {
+                                    splitline = line.Split('=');
+                                    string hash = "";
+                                    splitline[0] = line;
+                                    if (line.Contains('=')) //Let's make the = on the end of the lines optional
+                                    {
+                                        splitline = line.Split('=');
+                                        if (splitline.Length > 1)
+                                        {
+                                            hash = splitline[1];
+                                        }
+                                    }
+                                    hashes.Add(splitline[0], new SHAMod { sha = hash, required = false });
+                                }
+                                if (readmode == "resource")
+                                {
+                                    resources.Add(line);
+                                }
+                                if (readmode == "required")
+                                {
+                                    modList.Add(line);
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Info(e.ToString());
+                    }
+
+                }
+                partList = allowedParts; //make all the vars global once we're done parsing
+                modFileList = hashes;
+                resourceControlMode = resourcemode;
+                resourceList = resources;
+                requiredModList = modList;
+            }
         }
         
         private static bool FileCheck()
         {
-            char[] replaceChars = {'\\', '/'};
             try
             {
-                foreach (KeyValuePair<string, SHAMod> entry in modFileList)
+                //If required, check exists and same hash
+                foreach (KeyValuePair<string, SHAMod> entry in modFileList.Where(x => x.Value.required == true))
                 {
-                    // if server settings don't say to check all mod files, and it's not a DLL or CFG file, then skip it
-                    if (!gameManager.checkAllModFiles && !entry.Key.EndsWith(".cfg", System.StringComparison.InvariantCultureIgnoreCase) && !entry.Key.EndsWith(".dll", System.StringComparison.InvariantCultureIgnoreCase))
+                    if (entry.Key.EndsWith(".dll", StringComparison.CurrentCultureIgnoreCase))
                     {
-                        continue;
-                    }
-                    LoadedFileInfo FileInfo = null;
-                    if (resourceControlMode == "whitelist")
-                    {
-                        if (resourceList.Contains(entry.Key)) // don't check anything that has been specifically whitelisted
-                        {
-                            Log.Debug("SHA hash checking skipped due to whitelisting: " + entry.Key);
-                            continue;
-                        }
-                    }
-                    else if (entry.Key.StartsWith(PLUGIN_DATA_DIRECTORY) && (entry.Key.EndsWith(".txt") || entry.Key.EndsWith(".xml"))) // if using a blacklist, ignore any files in the KMP PluginData folder that are supposed to be there
-                    {
-                        Log.Debug("SHA hash checking skipped due to being a KMP file that changes: " + entry.Key);
-                        continue;
-                    }
-                    try
-                    {
-                        FileInfo = KMPManager.LoadedModfiles.SingleOrDefault(x => x.ModPath == entry.Key);
-                    }
-                    catch (InvalidOperationException)
-                    {
-                        modMismatchError = "Multiple of same file defined in different directories: " + entry.Key;
-                        return false;
-                    }
-                    if (FileInfo == null)
-                    {
-                        if (entry.Value.required) // the file doesn't exist, so refuse connection if it's a required mod
+                        //DLL's are checked against the load list
+                        if (KMPManager.LoadedModfiles.Where(x => x.ModPath == entry.Key).Count() == 0)
                         {
                             modMismatchError = "Required File Missing: " + entry.Key;
                             return false;
                         }
-                        else // if it's just an optional mod, continue because it's ok if it's missing
+                        if (KMPManager.LoadedModfiles.Where(x => x.ModPath == entry.Key && x.SHA256 == entry.Value.sha.ToUpperInvariant()).Count() == 0 && entry.Value.sha != "")
                         {
-                            continue;
+                            LoadedFileInfo debugTest = KMPManager.LoadedModfiles.Where(x => x.ModPath == entry.Key).First();
+
+                            modMismatchError = "SHA Checksum Mismatch: " + entry.Key + " " + debugTest.SHA256 + "/" + entry.Value.sha.ToUpperInvariant();
+                            return false;
                         }
                     }
-                    else if (String.Compare(FileInfo.SHA256, entry.Value.sha, true) != 0 && entry.Value.sha != "") // if the mod file exists, then it MUST match the SHA from the server (unless SHA section was blank, which means it is a required file but doesn't need to match)
+                    else
                     {
-                        modMismatchError = "SHA Checksum Mismatch: " + FileInfo.LoadedPath;
-                        return false;
+                        //All other files are checked against the filesystem
+                        string fileToCheck = System.IO.Path.Combine(GAMEDATAPATH, entry.Key);
+                        if (!System.IO.File.Exists(fileToCheck))
+                        {
+                            modMismatchError = "Required File Missing: " + entry.Key;
+                            return false;
+                        }
+                        if (entry.Value.sha != "")
+                        {
+                            try
+                            {
+                                using (System.IO.Stream hashStream = new System.IO.FileStream(fileToCheck, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite))
+                                {
+                                    using (SHA256Managed sha = new SHA256Managed())
+                                    {
+                                        byte[] hash = sha.ComputeHash(hashStream);
+                                        if (BitConverter.ToString(hash).Replace("-", String.Empty) != entry.Value.sha.ToUpperInvariant())
+                                        {
+                                            modMismatchError = "SHA Checksum Mismatch: " + entry.Key;
+                                            return false;
+                                        }
+                                    }
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Debug("Failed to hash: " + entry.Key + ", exception" + e.Message.ToString());
+                                modMismatchError = "Failed to hash: " + entry.Key;
+                                return false;
+                            }
+                        }
+                    }
+                }
+                //If optional, if exists check hash
+                foreach (KeyValuePair<string, SHAMod> entry in modFileList.Where(x => x.Value.required == false))
+                {
+                    if (entry.Key.EndsWith(".dll", StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        if (KMPManager.LoadedModfiles.Where(x => x.ModPath == entry.Key) != null)
+                        {
+                            if (KMPManager.LoadedModfiles.Where(x => x.ModPath == entry.Key && x.SHA256 == entry.Value.sha.ToUpperInvariant()) == null && entry.Value.sha != "")
+                            {
+                                modMismatchError = "SHA Checksum Mismatch: " + entry.Key;
+                                return false;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        string fileToCheck = System.IO.Path.Combine(GAMEDATAPATH, entry.Key);
+                        if (System.IO.File.Exists(fileToCheck) && entry.Value.sha != "")
+                        {
+                            using (System.IO.Stream hashStream = new System.IO.FileStream(fileToCheck, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite))
+                            {
+                                using (SHA256Managed sha = new SHA256Managed())
+                                {
+                                    byte[] hash = sha.ComputeHash(hashStream);
+                                    if (BitConverter.ToString(hash).Replace("-", String.Empty) != entry.Value.sha.ToUpperInvariant())
+                                    {
+                                        modMismatchError = "SHA Checksum Mismatch: " + entry.Key;
+                                        return false;
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
             catch (Exception e)
             {
+                Log.Debug("Failed to complete files check: " + e.ToString());
                 modMismatchError = e.Message;
                 return false;
             }
-	        return true;
-	    }
+            return true;
+        }
         
         
         private static bool resourceCheck()
         {
-        	try
-        	{
-	        	if(resourceControlMode == "blacklist")
-	        	{
-	        		foreach(string checkedResource in resourceList)
-	        		{
+            //We should auto-allow KMP resources.
+            List<string> allowList = new List<string>();
+            allowList.Add("000_Toolbar/Toolbar.dll");
+            allowList.Add("KMP/Plugins/KerbalMultiPlayer.dll");
+            allowList.Add("KMP/Plugins/ICSharpCode.SharpZipLib.dll");
+            try
+            {
+                if (resourceControlMode == "blacklist")
+                {
+                    foreach (string checkedResource in resourceList)
+                    {
                         foreach (LoadedFileInfo file in KMPManager.LoadedModfiles)
                         {
-	        				if(file.ModPath.Contains(checkedResource))
-	        				{
-                                modMismatchError = "File blacklisted: " + file.LoadedPath;
-	        					return false;
-	        				}
-	        			}
-	        		}
-	        	}
-	        	else if(resourceControlMode == "whitelist")
-	        	{
-                    foreach (LoadedFileInfo file in KMPManager.LoadedModfiles)
-                    {
-                        if (file.LoadedPath.StartsWith("Plugins") || file.LoadedPath.StartsWith("Parts")) // do not allow mod files that are in the Plugins or Parts directories (they load differently, and often cause errors). All mods should be in the GameData directory.
-                        {
-                            modMismatchError = "You may not join a server if you have mods installed in the deprecated mod directories ('Plugins' or 'Parts' directories in the KSP root directory)";
-                            return false;
-                        }
-                        // if server settings don't say to check all mod files, and it's not a DLL or CFG file, then skip it
-                        if (gameManager.checkAllModFiles || file.ModPath.EndsWith(".dll", System.StringComparison.InvariantCultureIgnoreCase) || file.ModPath.EndsWith(".cfg", System.StringComparison.InvariantCultureIgnoreCase))
-                        {
-                            if (!resourceList.Contains(file.ModPath) && !modFileList.ContainsKey(file.ModPath)) // check if the resource is a) whitelisted, or b) listed in the optional or required SHA sections. If not, the file is not allowed to be loaded.
+                            if (file.ModPath.Contains(checkedResource))
                             {
-                                modMismatchError = "File not allowed on this server: " + file.LoadedPath;
+                                modMismatchError = "File blacklisted: " + file.LoadedPath;
                                 return false;
                             }
                         }
-	        		}
-	        	}
-	        	return true;
-	        }
-	        catch (Exception e)
-	        {
+                    }
+                }
+                else if (resourceControlMode == "whitelist")
+                {
+                    foreach (LoadedFileInfo file in KMPManager.LoadedModfiles)
+                    {
+                        if (!resourceList.Contains(file.ModPath) && !modFileList.ContainsKey(file.ModPath) && !allowList.Contains(file.ModPath)) // check if the resource is a) whitelisted, or b) listed in the optional or required SHA sections. If not, the file is not allowed to be loaded.
+                        {
+                            modMismatchError = "File not allowed on this server: " + file.LoadedPath;
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+            catch (Exception e)
+            {
                 modMismatchError = e.Message;
-	        	Log.Debug(e.ToString());
-	        	return false;
-	        }
+                Log.Debug(e.ToString());
+                return false;
+            }
         }
         
         private static bool modCheck(byte[] kmpModControl_bytes)
@@ -801,7 +844,6 @@ namespace KMP
                             int kmpModControl_length = KMPCommon.intFromBytes(data, 16 + server_version_length);
                             kmpModControl_bytes = new byte[kmpModControl_length];
                             Array.Copy(data, 20 + server_version_length, kmpModControl_bytes, 0, kmpModControl_length);
-                            gameManager.checkAllModFiles = Convert.ToBoolean(data[20+server_version_length+kmpModControl_length]);
                             SetMessage("Handshake received. Server version: " + server_version);
                         }
                     }

--- a/KMPCommon.cs
+++ b/KMPCommon.cs
@@ -18,7 +18,7 @@ public class KMPCommon
     }
 
 	public const Int32 FILE_FORMAT_VERSION = 10000;
-	public const Int32 NET_PROTOCOL_VERSION = 10014;
+	public const Int32 NET_PROTOCOL_VERSION = 10015;
 	public const int MSG_HEADER_LENGTH = 8;
     public const int MAX_MESSAGE_SIZE = 1024 * 1024; //Enough room for a max-size craft file
 	public const int MESSAGE_COMPRESSION_THRESHOLD = 4096;

--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -52,10 +52,7 @@ namespace KMPServer
         public const string DB_FILE_CONN = "Data Source=KMP_universe.db";
         public const string DB_FILE = "KMP_universe.db";
         public const string MOD_CONTROL_FILE = "KMPModControl.txt";
-        public const string REQUIRED_MODS_PATH = "Mods/Required";
-        public const string OPTIONAL_MODS_PATH = "Mods/Optional";
-        public const string REQUIRED_EXACT_MODS_PATH = "Mods/Required_Exact";
-        public const string OPTIONAL_EXACT_MODS_PATH = "Mods/Optional_Exact";
+        public const string MODS_PATH = "Mods";
 
         public const string PLUGIN_DATA_DIRECTORY = "KMP/Plugins/PluginData/KerbalMultiPlayer/";
         public const string CLIENT_CONFIG_FILENAME = "KMPClientConfig.xml";
@@ -309,52 +306,118 @@ namespace KMPServer
             catch
             {
             	Log.Info(MOD_CONTROL_FILE + " not found, generating...");
-                writeModControl(false, null);
+                //Generate a default blacklist no-sha file.
+                writeModControl(true, false);
             }
         }
 
-        public static string ModFilesToListing(string path, bool checkSHA, ServerSettings.ConfigStore ServerSettings, out string[] files)
+        public static string ModFilesToListing(string mode, bool sha)
         {
             string result = "";
-            if (path[path.Length - 1] == '/')
-                path = path.Substring(0, path.Length - 1);
-            string[] pathsplit = path.Split('/');
-            string dirname = pathsplit[pathsplit.Length - 1];
-            try
-            {
-                files = System.IO.Directory.GetFiles(path, "*.*", System.IO.SearchOption.AllDirectories);
-            }
-            catch (DirectoryNotFoundException)
-            {
-                Log.Info(dirname + " mods directory not found, creating...");
-                System.IO.Directory.CreateDirectory(path);
-                files = new string[0];
-            }
-            SHA256Managed sha = new SHA256Managed();
-            foreach (string file in files)
-            {
-                if (ServerSettings.checkAllModFiles || file.EndsWith(".cfg", StringComparison.InvariantCultureIgnoreCase) || file.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase)) //add this file if it's a CFG file, a DLL file, or if the admin wants to do string checking with all files
+            if (mode == "required" || mode == "optional") {
+                string[] lsDirectory = Directory.GetDirectories(MODS_PATH);
+                foreach (string modDirectory in lsDirectory)
                 {
-                    result += file.Substring(path.Length + 1).Replace("\\", "/") + "="; // cut off first part of path so it starts from GameData directory, make unix-safe
-                    if (checkSHA)
+                    string modType = "optional";
+                    string[] lsFiles = Directory.GetFiles(modDirectory, "*", SearchOption.AllDirectories);
+                    List<string> dllFiles = new List<string>();
+                    foreach (string modFile in lsFiles)
                     {
-                        using (FileStream stream = File.OpenRead(file))
+                        //Remove the Mods/ part, Change path seperators to the unix ones.
+                        string trimmedModFile = modFile.Remove(0, MODS_PATH.Length + 1);
+                        if (!trimmedModFile.ToLowerInvariant().StartsWith("squad") && !trimmedModFile.ToLowerInvariant().StartsWith("kmp") && !trimmedModFile.ToLowerInvariant().StartsWith("000_toolbar"))
+                            if (trimmedModFile.ToLowerInvariant().EndsWith(".cfg"))
                         {
-                            byte[] hash = sha.ComputeHash(stream);
-                            result += BitConverter.ToString(hash).Replace("-", String.Empty);
+                            using (StreamReader sr = new StreamReader(modFile))
+                            {
+                                string line;
+                                while ((line = sr.ReadLine()) != null)
+                                {
+                                    if (line.Contains("PART")) {
+                                        modType = "required";
+                                    }
+                                }
+                            }
+                        }
+                        if (trimmedModFile.ToLowerInvariant().EndsWith(".dll"))
+                        {
+							dllFiles.Add(modFile);
                         }
                     }
-                    result += "\n";
+
+                    if (modType == mode) {
+                        foreach (string dllFile in dllFiles)
+                        {
+                            //Remove the Mods/ part, Change path seperators to the unix ones.
+                            string trimmedDllFile = dllFile.Remove(0, MODS_PATH.Length + 1).Replace("\\", "/");
+                            Log.Info("Adding " + trimmedDllFile + " into the " + modType + " section.");
+                            result += trimmedDllFile;
+                            //We shouldn't ever care what version of non-part-adding mods the client has.
+                            if (sha && modType == "required")
+                            {
+                                using (SHA256Managed shaManager = new SHA256Managed()) {
+                                    using (FileStream stream = File.OpenRead(dllFile))
+                                    {
+                                        byte[] hash = shaManager.ComputeHash(stream);
+                                        result += "=" + BitConverter.ToString(hash).Replace("-", String.Empty);
+                                    }
+                                }
+                            }
+                            result += "\n";
+                        }
+                    }
+                }
+            }
+
+            if (mode == "resource-whitelist") {
+                string[] lsFiles = Directory.GetFiles(MODS_PATH, "*", SearchOption.AllDirectories);
+                foreach (string modFile in lsFiles)
+                {
+					string trimmedModFile = modFile.Remove(0, MODS_PATH.Length + 1).Replace("\\", "/");
+                    if (!trimmedModFile.ToLowerInvariant().StartsWith("squad") && !trimmedModFile.ToLowerInvariant().StartsWith("kmp") && !trimmedModFile.ToLowerInvariant().StartsWith("000_toolbar") && trimmedModFile.ToLowerInvariant().EndsWith(".dll"))
+                    {
+						result += modFile.Remove(0, MODS_PATH.Length + 1).Replace("\\", "/") + "\n"; //Remove the starting parth and add it to the list.
+                    }
                 }
             }
             return result;
         }
 
-        public static void writeModControl(bool autoAdd, ServerSettings.ConfigStore ServerSettings)
+        public static void writeModControlCommand(string[] input)
         {
+            string[] commandParts = new string[0];
+            if (input.Length == 2)
+            {
+                commandParts = input[1].Split(new char[] { ' ' });
+            }
+            bool blacklist = true;
+            bool sha = false;
+            //This allows a user to type the modgen parameters in any order.
+            foreach (string part in commandParts)
+            {
+                if (part.ToLowerInvariant() == "whitelist")
+                {
+                    blacklist = false;
+                }
+                if (part.ToLowerInvariant() == "sha")
+                {
+                    sha = true;
+                }
+            }
+            writeModControl(blacklist, sha);
+        }
+
+        public static void writeModControl(bool blacklist, bool sha)
+        {
+            bool autoAdd = Directory.GetDirectories(MODS_PATH).Count() > 0;
+            if (!autoAdd)
+            {
+                Log.Info("To generate an automatic KMPModControl.txt file, Copy mods from the GameData directory to the '" + MODS_PATH + "' folder.");
+            }
             string filestring = "\n" +
                 "#You can comment by starting a line with a #, these are ignored by the server.\n" +
                 "#Commenting will NOT work unless the line STARTS with a '#'.\n" +
+                "#You can also indent the file with tabs or spaces.\n" +
                 "#Sections supported are required-files, optional-files, partslist, resource-blacklist and resource-whitelist.\n" +
                 "#The client will be required to have the files found in required-files, and they must match the SHA hash if specified (this is where part mod files and play-altering files should go, like KWRocketry or Ferram Aerospace Research" +
                 "#The client may have the files found in optional-files, but IF they do then they must match the SHA hash (this is where mods that do not affect other players should go, like EditorExtensions or part catalogue managers\n" +
@@ -367,104 +430,42 @@ namespace KMPServer
                 "\n" +
                 "!required-files" +
                 "\n" +
-                "#To generate the SHA of a file you can use a utility such as this one: http://hash.online-convert.com/sha256-generator (use the 'hex' string)\n" +
-                "#For the Required section, file paths are read from inside GameData. If there is no SHA hash listed here (i.e. blank after the equals sign), SHA matching will not be enforced. Otherwise, if a client's SHA does not match they will not be permitted entry.\n" +
+                "#To generate the SHA256 of a file you can use a utility such as this one: http://hash.online-convert.com/sha256-generator (use the 'hex' string), or use sha256sum on linux.\n" +
+                "#File paths are read from inside GameData.\n" +
+                "#If there is no SHA256 hash listed here (i.e. blank after the equals sign or no equals sign), SHA matching will not be enforced.\n" +
                 "#You may not specify multiple SHAs for the same file. Do not put spaces around equals sign. Follow the example carefully.\n" +
-                "#[File Path]=[SHA]\n" +
-                "#Example: MechJeb2/Plugins/MechJeb2.dll=B84BB63AE740F0A25DA047E5EDA35B26F6FD5DF019696AC9D6AF8FC3E031F0B9\n\n";
-
-            Log.Info("Beginning SHA256 hash of required mod files...");
-            string[] ls_required = null;
-            string[] ls_required_exact = null;
-            if (autoAdd) // auto-add required mod list
+                "#Syntax:\n" +
+                "#[File Path]=[SHA] or [File Path]\n" +
+                "#Example: MechJeb2/Plugins/MechJeb2.dll=B84BB63AE740F0A25DA047E5EDA35B26F6FD5DF019696AC9D6AF8FC3E031F0B9\n" +
+                "#Example: MechJeb2/Plugins/MechJeb2.dll\n\n";
+            if (autoAdd)
             {
+                Log.Info("Beginning SHA256 hash of required mod files...");
                 // add mods that user must have, but don't have to match SHA hash
-                filestring += ModFilesToListing(REQUIRED_MODS_PATH, false, ServerSettings, out ls_required);
-
-                // add mods that user must have, AND must match SHA hash
-                filestring += ModFilesToListing(REQUIRED_EXACT_MODS_PATH, true, ServerSettings, out ls_required_exact);
+                filestring += ModFilesToListing("required", sha);
             }
-
             filestring += "\n\n!optional-files\n" +
                 "#Formatting for this section is the same as the 'required-files' section\n\n";
-
-            Log.Info("Beginning SHA256 hash of optional mod files...");
-            string[] ls_optional = null;
-            string[] ls_optional_exact = null;
-            if (autoAdd) // auto-add optional mod list
+            if (autoAdd)
             {
-                // add mods that user may have, but don't have to match SHA hash
-                filestring += ModFilesToListing(OPTIONAL_MODS_PATH, false, ServerSettings, out ls_optional);
-
-                // add mods that user may have, but if they do then they must match SHA hash
-                filestring += ModFilesToListing(OPTIONAL_EXACT_MODS_PATH, true, ServerSettings, out ls_optional_exact);
+                Log.Info("Beginning SHA256 hash of optional mod files...");
+                filestring += ModFilesToListing("optional", sha);
             }
-
-            string resourcelistDescription = "#Set this to 'resource-blacklist' and specify the files to ban:\n" +
-                    "#[File]\n" +
-                    "#Example: MechJeb2.dll\n" +
-                    "#Alternatively, change 'blacklist' to 'whitelist' and clients will only be allowed to use parts listed here or in the 'required-files' and 'optional-files' sections.\n" +
-                    "#This is useful for when you use the 'checkAllModFiles' setting with mods that create or edit files as the user plays (for example, KMP modifies the 'KMPPlayerToken.txt' file for each user)\n" +
-                    "#In this case, you must specify the path AND filename:\n" +
+            if (blacklist) {
+                filestring += "\n\n!resource-blacklist\n#!resource-whitelist\n\n";
+				filestring += "#Alternatively, change 'blacklist' to 'whitelist' and clients will only be allowed to use dll's listed here or in the 'required-files' and 'optional-files' sections.\n";
+            } else {
+                filestring += "\n\n!resource-whitelist\n#!resource-blacklist\n\n";
+				filestring += "#Alternatively, change 'whitelist' to 'blacklist' and clients will not be allowed to use dll's listed here.\n";
+            }
+            filestring += "#You can ban specific files in resource-blacklist mode, or only allow specific files in resource-whitelist mode.\n" +
+                    "#Syntax:\n" +
                     "#[File Path]\n" +
-                    "#Example: KMP/Plugins/PluginData/KerbalMultiPlayer/KMPPlayerToken.txt\n\n";
+					"#Example: MechJeb2/Plugins/MechJeb2.dll\n\n";
 
-            if(autoAdd){ // this section adds the whitelist from the existing file if it has one, so the user doesn't have to re-add any whitelisted files after auto-generating the Mod Control text file
-                string resourcelist = "";
-                try
-                {
-                    Log.Info("Looking for mod control file to preserve existing whitelist");
-                    using (StreamReader sr = new StreamReader(MOD_CONTROL_FILE))
-                    {
-                        string line;
-                        bool startedList = false;
-                        while (!sr.EndOfStream)
-                        {
-                            line = sr.ReadLine().Trim();
-                            if (line.Equals("!resource-whitelist", StringComparison.InvariantCultureIgnoreCase)) // wait until you find the whitelist section
-                            {
-                                startedList = true;
-                                continue;
-                            }
-                            if(!startedList) // skip all lines before you find it
-                            {
-                                continue;
-                            }
-                            if (line.Length > 0) // skip blank lines
-                            {
-                                if (line[0] == '!') // end at the next control section
-                                    break;
-                                if (line[0] == '#') // skip commented lines
-                                    continue;
-                                resourcelist += line + "\n";
-                            }
-                        }
-                    }
-                }
-                catch 
-                {
-                    Log.Info("No existing mod control file found");
-                }
-                string[] requiredWhitelist = {  PLUGIN_DATA_DIRECTORY + CLIENT_CONFIG_FILENAME + "\n",
-                                                PLUGIN_DATA_DIRECTORY + CLIENT_TOKEN_FILENAME + "\n",
-                                                PLUGIN_DATA_DIRECTORY + GLOBAL_SETTINGS_FILENAME + "\n",
-                                                PLUGIN_DATA_DIRECTORY + MOD_CONTROL_FILE + "\n"
-                                             };
-                foreach (string item in requiredWhitelist)
-                {
-                    if(!resourcelist.Contains(item)){
-                        resourcelist += item;
-                    }
-                }
-                filestring += "\n\n!resource-whitelist\n" +
-                    resourcelistDescription +
-                    resourcelist;
-            
-            } else
-            {
-                filestring += "\n\n" +
-                    "!resource-blacklist\n" +
-                    resourcelistDescription;
+			//We don't need to write any files here in blacklist mode.
+            if (autoAdd && !blacklist) {
+                filestring += ModFilesToListing("resource-whitelist", sha);
             }
 
             filestring += "\n\n" +
@@ -479,14 +480,16 @@ namespace KMPServer
                 "\n";
 
             List<string> parts = new List<string>();
+            parts = generatePartsList();
             if (autoAdd) // add a part list for all part in the Required and Optional folders
             {
-                string[] ls = ls_required.Concat(ls_required_exact).Concat(ls_optional).Concat(ls_optional_exact).ToArray(); // put files from both optional and required directories together
+                string[] ls = Directory.GetFiles(MODS_PATH, "*", SearchOption.AllDirectories);
                 ls = ls.Distinct().ToArray();
                 char[] toperiod = { ' ', '_' };
                 foreach (string file in ls)
                 {
-                    if (file.Substring(file.Length - 4).Equals(".cfg", StringComparison.InvariantCultureIgnoreCase)) // check if config file (only place where parts are located)
+                    //We add Squad files manually in generatePartsList above.
+                    if (!file.ToLowerInvariant().StartsWith("squad") && file.Substring(file.Length - 4).Equals(".cfg", StringComparison.InvariantCultureIgnoreCase)) // check if config file (only place where parts are located)
                     {
                         using (StreamReader sr = new StreamReader(file))
                         {
@@ -512,10 +515,6 @@ namespace KMPServer
                     }
                 }
                 parts = parts.Distinct().ToList();
-            }
-            else
-            {
-                parts = generatePartsList();
             }
             foreach (string part in parts)
             {
@@ -778,7 +777,7 @@ namespace KMPServer
 					case "/motd": motdServerCommand(rawParts); break;
 					case "/rules": rulesServerCommand(rawParts); break;
 					case "/setinfo": serverInfoServerCommand(rawParts);break;
-                    case "/modgen": writeModControl(true, settings); break;
+                    case "/modgen": writeModControlCommand(parts); break;
                     default: Log.Info("Unknown Command: "+cleanInput); break;
             	}
 			}
@@ -2949,9 +2948,6 @@ namespace KMPServer
 			
             KMPCommon.intToBytes(kmpModControl.Length).CopyTo(data_bytes, 16 + version_bytes.Length);
             kmpModControl.CopyTo(data_bytes, 20 + version_bytes.Length);
-
-            //Add checkAllModFiles setting to the handshake message
-            data_bytes[20 + version_bytes.Length + kmpModControl.Length] = Convert.ToByte(settings.checkAllModFiles);
 
             cl.queueOutgoingMessage(KMPCommon.ServerMessageID.HANDSHAKE, data_bytes);
         }

--- a/KMPServer/ServerMain.cs
+++ b/KMPServer/ServerMain.cs
@@ -20,20 +20,9 @@ namespace KMPServer
 
 		static void Main(string[] args)
 		{
-            if (!System.IO.Directory.Exists(Server.REQUIRED_MODS_PATH))
+            if (!System.IO.Directory.Exists(Server.MODS_PATH))
             {
-                System.IO.Directory.CreateDirectory(Server.REQUIRED_MODS_PATH);
-            }
-            if(!System.IO.Directory.Exists(Server.OPTIONAL_MODS_PATH)){
-                System.IO.Directory.CreateDirectory(Server.OPTIONAL_MODS_PATH);
-            }
-            if (!System.IO.Directory.Exists(Server.REQUIRED_EXACT_MODS_PATH))
-            {
-                System.IO.Directory.CreateDirectory(Server.REQUIRED_EXACT_MODS_PATH);
-            }
-            if (!System.IO.Directory.Exists(Server.OPTIONAL_EXACT_MODS_PATH))
-            {
-                System.IO.Directory.CreateDirectory(Server.OPTIONAL_EXACT_MODS_PATH);
+                System.IO.Directory.CreateDirectory(Server.MODS_PATH);
             }
 			settings = new ServerSettings.ConfigStore();
 			ServerSettings.readFromFile(settings);
@@ -105,7 +94,7 @@ namespace KMPServer
             Log.Info("/whitelist [add|del] [user] to update whitelist.");
             Log.Info("/admin [add|del] [user] to update admin list.");
             Log.Info("/mode [sandbox|career] to set server game mode.");
-            Log.Info("/modgen - Auto-generate a KMPModControl.txt file using what you have placed in the server's 'Mods' directory.\n");
+            Log.Info("/modgen [blacklist|whitelist] [sha] - Generate a KMPModControl.txt from the 'Mods' directory.\nYou can use blacklist or whitelist mode, defaulting to blacklist.\nYou can optionally specify sha to force required versions.\n");
             Log.Info("/quit to exit, or /start to begin the server.");
             Log.Info("");
 
@@ -159,7 +148,7 @@ namespace KMPServer
                     case "/quit":
                         return;
                     case "/modgen":
-                        Server.writeModControl(true, settings);
+                        Server.writeModControlCommand(parts);
                         break;
                     case "/whitelist":
                         if (parts.Length != 3)
@@ -289,7 +278,6 @@ namespace KMPServer
                             Log.Info("autoDekesslerTime - Time, in minutes, that the server will clean up all debris." + Environment.NewLine);
                             Log.Info("profanityWords - Replaces the first word with the second." + Environment.NewLine);
                             Log.Info("consoleScale - Changes the window size of the scale. Defaults to 1.0, requires restart." + Environment.NewLine);
-                            Log.Info("checkAllModFiles - If true, all files in the Mods directories are used during the /modgen command. Otherwise, only .dll and .cfg files are used." + Environment.NewLine);
                         }
                         else if (parts.Length < 3)
                         {


### PR DESCRIPTION
Now ready to merge.

Server:
Makes a very sane KMPModControl.txt file.
The /modgen command is fairly clever:
You can type "/modgen whitelist sha", "/modgen blacklist" etc, but you can also type "/modgen please make me a whitelist file that has sha hashes kthxbye.".
the 'sha' part of the command only adds hashes in the required section. We don't need to force versions of kerbal alarm clock.
It puts part adding mods into the required section and non-part-adding mods into the optional section automatically.

Client:
No more sharing violations.
Only hashes dll's at startup, making the startup lag not noticeable. Configs are not important and are usually loaded later.
Required files are actually required for reals now (it currently will ignore required files if they are in the whitelist section - which is insane)
