### PR TITLE
Avoid some NRE's in the logs.

### DIFF
--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -740,7 +740,7 @@ namespace KMP
 
                     SetMessage("Connected to server! Handshaking...");
 
-                    while (!endSession && !intentionalConnectionEnd && tcpClient.Connected)
+                    while (!endSession && !intentionalConnectionEnd && tcpClient != null)
                     {
                         //Check for exceptions thrown by threads
                         lock (threadExceptionLock)
@@ -1627,11 +1627,11 @@ namespace KMP
 
         static void processPluginInterop()
         {
-			if (interopInQueue.Count > 0 )
+			if (interopInQueue.Count > 0 && tcpClient != null )
 			{
 				try
 				{
-				while (interopInQueue.Count > 0 && tcpClient.Connected)
+				while (interopInQueue.Count > 0 && tcpClient != null)
 					{
 						byte[] bytes;
 						bytes = interopInQueue.Dequeue();

--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -4100,7 +4100,7 @@ namespace KMP
 					bool quit = GUILayout.Button("Quit",lockButtonStyle);
 					if (quit)
 					{
-						if (KMPClientMain.tcpClient.Connected) {
+						if (KMPClientMain.tcpClient != null) {
 							KMPClientMain.sendConnectionEndMessage("Requested quit during sync");
 						}
 						KMPClientMain.endSession = true;
@@ -5227,13 +5227,21 @@ namespace KMP
 		//This code adapted from Kerbal Engineer Redux source
 		private void CheckEditorLock()
 		{
-			if (gameRunning && shouldDrawGUI && HighLogic.LoadedSceneIsEditor)
+			if (!gameRunning || !HighLogic.LoadedSceneIsEditor) {
+				//Only handle editor locks while in the editor
+				return;
+			}
+			EditorLogic editorObject = EditorLogic.fetch;
+			if (editorObject == null) {
+				//If the editor isn't initialized, return early. This stops debug log spam.
+				return;
+			}
+			if (shouldDrawGUI)
 			{
 				Vector2 mousePos = Input.mousePosition;
 				mousePos.y = Screen.height - mousePos.y;
 	
-				bool should_lock = (KMPInfoDisplay.infoWindowPos.Contains(mousePos)
-					|| (KMPScreenshotDisplay.windowEnabled && KMPScreenshotDisplay.windowPos.Contains(mousePos)));
+				bool should_lock = (KMPInfoDisplay.infoWindowPos.Contains(mousePos)	|| (KMPScreenshotDisplay.windowEnabled && KMPScreenshotDisplay.windowPos.Contains(mousePos)));
 				
 				if (should_lock && !isEditorLocked)
 				{
@@ -5242,14 +5250,14 @@ namespace KMP
 				}
 				else if (!should_lock)
 				{
-					if (!isEditorLocked) EditorLogic.fetch.Lock(true, true, true,"KMP_lock");
-					EditorLogic.fetch.Unlock("KMP_lock");
+					if (!isEditorLocked) editorObject.Lock(true, true, true,"KMP_lock");
+					editorObject.Unlock("KMP_lock");
 					isEditorLocked = false;
 				}
 			}
 			//Release the lock if the KMP window is hidden.
-			if (gameRunning && !shouldDrawGUI && isEditorLocked && HighLogic.LoadedSceneIsEditor) {
-				EditorLogic.fetch.Unlock("KMP_lock");
+			if (!shouldDrawGUI && isEditorLocked) {
+				editorObject.Unlock("KMP_lock");
 				isEditorLocked = false;
 			}
 		}


### PR DESCRIPTION
This is more to keep our debug logs a little cleaner.

The worst one was processPluginInterop, it caused an NRE flood upon disconnect.

CheckEditorLock caused exceptions when moving the mouse over the KMP windows before the editor initialized (which takes a second or two) - but this change is mainly to reduce the log noise.

If we are testing for disconnections we should be testing tcpClient for null, as disconnect calls TcpClient.Close() which happens to disposes the object, which causes an NRE upon if-testing the .Connected variable anywhere else in the code.
