### PR TITLE
Improve ntp messages

### DIFF
--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -1167,6 +1167,11 @@ namespace KMP
                             pingStopwatch.Start();
                         }
                     }
+                    else if (line_lower == "!ntp")
+                    {
+                        handled = true;
+                        gameManager.displayNTP = !gameManager.displayNTP;
+                    }
                     else if (line_lower == "!debug")
                     {
                         handled = true;

--- a/KMPServer/Server.cs
+++ b/KMPServer/Server.cs
@@ -2752,6 +2752,8 @@ namespace KMPServer
                         sb.Append("!chat offsetting <true|false> - Turn on/off the tracking center and editor offsets\n");
                         sb.Append("!chat offset [tracking|editor] [offsetX] [offsetY] - Set the offset values (pixels)\n");
                         sb.Append("!chat [width|height|top|left] [value] <percent|pixels>\n");
+                        sb.Append("!ping - Shows current server latency\n");
+                        sb.Append("!ntp - Displays NTP-sync status\n");
                         sb.Append("!whereami - Displays server connection information\n");
 						if(isAdmin(cl.username)) {
 							sb.Append(KMPCommon.RCON_COMMAND + " <cmd> - Execute command /<cmd> as if typed from server console\n");


### PR DESCRIPTION
This removes the "Time Skew Error:" message and replaces it with a toggle-able !ntp command, which shows various variables from NTP-sync.

I was tempted to put it in #if DEBUG, but I assume someone will like to toggle the random info :)
