### PR TITLE
Improve NTP accuracy, show server lag.

### DIFF
--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -182,6 +182,7 @@ namespace KMP
 		private bool isSkewingTime = false;
 		private Int64 offsetSyncTick = 0; //The difference between the servers system clock and ours.
 		private Int64 latencySyncTick = 0; //The network lag detected by NTP.
+		private Int64 estimatedServerLag = 0; //The server lag detected by NTP.
 		private List<Int64> listClientTimeSyncLatency = new List<Int64>(); //Holds old sync time messages so we can filter bad ones
 		private List<Int64> listClientTimeSyncOffset = new List<Int64>(); //Holds old sync time messages so we can filter bad ones
 		public List<float> listClientTimeWarp = new List<float>(); //Holds the average time skew so we can tell the server how badly we are lagging.
@@ -3629,7 +3630,18 @@ namespace KMP
 					long offsetSyncTickMilliseconds = tempOffsetSyncTick / 10000;
 					skewMessageText += offsetSyncTickMilliseconds + "ms.\n";
 					//Current subspace speed
-					skewMessageText += "Subspace Speed: " + Math.Round(skewSubspaceSpeed, 3) + "x.";
+					skewMessageText += "Subspace Speed: " + Math.Round(skewSubspaceSpeed, 3) + "x.\n";
+					//Estimated server lag
+					skewMessageText += "Server lag: ";
+					long tempServerLag = estimatedServerLag;
+					long serverLagSeconds = tempServerLag / 10000000;
+					tempServerLag -= serverLagSeconds * 10000000;
+					if (serverLagSeconds > 0) {
+						skewMessageText += serverLagSeconds + "s, ";
+					}
+					long serverLagMilliseconds = tempServerLag / 10000;
+					skewMessageText += serverLagMilliseconds + "ms.\n";
+
 					skewMessage = ScreenMessages.PostScreenMessage(skewMessageText, 1f, ScreenMessageStyle.UPPER_RIGHT);
 				}
 			}
@@ -3651,6 +3663,7 @@ namespace KMP
 			//Fancy NTP algorithm
 			Int64 clientLatency = (clientReceive - clientSend) - (serverSend - serverReceive);
 			Int64 clientOffset = ((serverReceive - clientSend) + (serverSend - clientReceive))/2;
+			estimatedServerLag = serverSend - serverReceive;
 
 			//If time is synced, throw out outliers.
 			if (isTimeSyncronized) {

--- a/KMPServer/Client.cs
+++ b/KMPServer/Client.cs
@@ -427,32 +427,32 @@ namespace KMPServer
 
 		private void messageReceived (KMPCommon.ClientMessageID id, byte[] data)
 		{
-				if (id == KMPCommon.ClientMessageID.SPLIT_MESSAGE) {
-						if (splitMessageReceiveIndex == 0) {
-							//New split message
-								int split_message_length = KMPCommon.intFromBytes (data, 4);
-								splitMessageData = new byte[8 + split_message_length];
-								data.CopyTo (splitMessageData, 0);
-								splitMessageReceiveIndex = data.Length;
-						} else {
-								//Continued split message
-								data.CopyTo (splitMessageData, splitMessageReceiveIndex);
-								splitMessageReceiveIndex = splitMessageReceiveIndex + data.Length;
-						}
-						//Check if we have filled the byte array, if so, handle the message.
-						if (splitMessageReceiveIndex == splitMessageData.Length) {
-								//Parse the message and feed it into the client queue
-								KMPCommon.ClientMessageID joined_message_id = (KMPCommon.ClientMessageID)KMPCommon.intFromBytes (splitMessageData, 0);
-								int joined_message_length = KMPCommon.intFromBytes (splitMessageData, 4);
-								byte[] joined_message_data = new byte[joined_message_length];
-								Array.Copy (splitMessageData, 8, joined_message_data, 0, joined_message_length);
-								byte[] joined_message_data_decompressed = KMPCommon.Decompress (joined_message_data);
-								parent.queueClientMessage (this, joined_message_id, joined_message_data_decompressed);
-								splitMessageReceiveIndex = 0;
-						}
+			if (id == KMPCommon.ClientMessageID.SPLIT_MESSAGE) {
+				if (splitMessageReceiveIndex == 0) {
+					//New split message
+					int split_message_length = KMPCommon.intFromBytes (data, 4);
+					splitMessageData = new byte[8 + split_message_length];
+					data.CopyTo (splitMessageData, 0);
+					splitMessageReceiveIndex = data.Length;
 				} else {
-						parent.queueClientMessage (this, id, data);
+					//Continued split message
+					data.CopyTo (splitMessageData, splitMessageReceiveIndex);
+					splitMessageReceiveIndex = splitMessageReceiveIndex + data.Length;
 				}
+				//Check if we have filled the byte array, if so, handle the message.
+				if (splitMessageReceiveIndex == splitMessageData.Length) {
+					//Parse the message and feed it into the client queue
+					KMPCommon.ClientMessageID joined_message_id = (KMPCommon.ClientMessageID)KMPCommon.intFromBytes (splitMessageData, 0);
+					int joined_message_length = KMPCommon.intFromBytes (splitMessageData, 4);
+					byte[] joined_message_data = new byte[joined_message_length];
+					Array.Copy (splitMessageData, 8, joined_message_data, 0, joined_message_length);
+					byte[] joined_message_data_decompressed = KMPCommon.Decompress (joined_message_data);
+					parent.queueClientMessage (this, joined_message_id, joined_message_data_decompressed);
+					splitMessageReceiveIndex = 0;
+				}
+			} else {
+				parent.queueClientMessage (this, id, data);
+			}
 		}
 
 		public void sendOutgoingMessages()


### PR DESCRIPTION
I wasn't writing the receive time before it entered the queue, so the clock offset was roughly half server cpu lag on 2 real-ntp synced machines.

Writing it before the queue also gives us the advantage to display the server message handling lag time.
