### PR TITLE
Fix issue #684, Server output in a different colour.

### DIFF
--- a/KMPClientMain.cs
+++ b/KMPClientMain.cs
@@ -1843,7 +1843,7 @@ namespace KMP
             if (to_plugin)
             {
                 if (message.fromServer)
-                    enqueuePluginChatMessage("[Server] " + message.message, false);
+                    enqueuePluginChatMessage("<Server> " + message.message, false);
                 else if (message.isMOTD)
                     enqueuePluginChatMessage("[MOTD] " + message.message, false);
                 else


### PR DESCRIPTION
ChatDX looks for <Server>, not [Server].
