### PR TITLE
Make server setting matching case-insensitive

### DIFF
--- a/KMPServer/ServerMain.cs
+++ b/KMPServer/ServerMain.cs
@@ -298,12 +298,13 @@ namespace KMPServer
                         else
                         {
                             string val = String.Join(" ", parts.Skip(2).ToArray());
-                            if (settings.Contains(parts[1]))
+                            string setKey = settings.MatchCaseInsensitive(parts[1]);
+                            if (settings.Contains(setKey))
                             {
                                 try
                                 {
-                                    ServerSettings.modifySetting(settings, parts[1], val);
-                                    Log.Info("{0} changed to {1}", parts[1], val);
+                                    ServerSettings.modifySetting(settings, setKey, val);
+                                    Log.Info("{0} changed to {1}", setKey, val);
                                     ServerSettings.writeToFile(settings);
                                 }
                                 catch

--- a/KMPServer/ServerSettings.cs
+++ b/KMPServer/ServerSettings.cs
@@ -132,6 +132,16 @@ namespace KMPServer
 			{
 				return ServerSettings.Contains(typeof(ServerSettings.ConfigStore), sKey);
 			}
+
+			public string MatchCaseInsensitive (String sKey)
+			{
+				foreach (string fieldName in typeof(ConfigStore).GetFields().Select(field => field.Name)) {
+					if (fieldName.ToLowerInvariant () == sKey.ToLowerInvariant ()) {
+						return fieldName;
+					}
+				}
+				return "";
+			}
 		}
 
 		public const int MIN_UPDATE_INTERVAL = 250;


### PR DESCRIPTION
Mainly for convenience, but also because some settings are camelCase, some settings are PascalCase, and some settings are lowercase.

And this:
http://forum.kerbalspaceprogram.com/threads/55835-KMP-v0-1-5-1-0-23-wip-alpha?p=982353&viewfull=1#post982353

EDIT: And now my spelling mistake of the branch name shall forever be in history...
