### PR TITLE
Drop UDP support.

### DIFF
--- a/KMPCommon.cs
+++ b/KMPCommon.cs
@@ -18,7 +18,7 @@ public class KMPCommon
     }
 
 	public const Int32 FILE_FORMAT_VERSION = 10000;
-	public const Int32 NET_PROTOCOL_VERSION = 10015;
+	public const Int32 NET_PROTOCOL_VERSION = 10016;
 	public const int MSG_HEADER_LENGTH = 8;
     public const int MAX_MESSAGE_SIZE = 1024 * 1024; //Enough room for a max-size craft file
 	public const int MESSAGE_COMPRESSION_THRESHOLD = 4096;
@@ -78,7 +78,7 @@ public class KMPCommon
 		SCREENSHOT_SHARE /*Description Length : Description : data*/,
 		KEEPALIVE,
 		CONNECTION_END /*Message*/ ,
-		UDP_PROBE,
+		PROBE,
 		NULL,
 		SHARE_CRAFT_FILE /*Craft Type Byte : Craft name length : Craft Name : File bytes*/,
 		ACTIVITY_UPDATE_IN_GAME,
@@ -103,7 +103,6 @@ public class KMPCommon
 		SCREENSHOT_SHARE /*Description Length : Description : data*/,
 		KEEPALIVE,
 		CONNECTION_END /*Message*/,
-		UDP_ACKNOWLEDGE,
 		NULL,
 		CRAFT_FILE /*Craft Type Byte : Craft name length : Craft Name : File bytes*/,
 		PING_REPLY,

--- a/KMPServer/Client.cs
+++ b/KMPServer/Client.cs
@@ -56,7 +56,6 @@ namespace KMPServer
 		public long connectionStartTime;
 		public long lastReceiveTime;
 		public long lastSyncTime;
-		public long lastUDPACKTime;
         public long lastPollTime = 0;
 
 		public long lastInGameActivityTime;
@@ -173,8 +172,6 @@ namespace KMPServer
 			sharedCraftFile = null;
 			sharedCraftName = String.Empty;
 			sharedCraftType = KMPCommon.CraftType.VAB;
-
-			lastUDPACKTime = 0;
 
 			queuedOutMessagesHighPriority = new ConcurrentQueue<byte[]>();
 			queuedOutMessagesSplit = new ConcurrentQueue<byte[]>();
@@ -552,7 +549,6 @@ namespace KMPServer
 						case (int)KMPCommon.ServerMessageID.SERVER_SETTINGS:
 						case (int)KMPCommon.ServerMessageID.KEEPALIVE:
 						case (int)KMPCommon.ServerMessageID.CONNECTION_END:
-						case (int)KMPCommon.ServerMessageID.UDP_ACKNOWLEDGE:
 						case (int)KMPCommon.ServerMessageID.PING_REPLY:
 								queuedOutMessagesHighPriority.Enqueue(message_bytes);
 								break;


### PR DESCRIPTION
We handle the TCP stream well enough that this should no longer be required.

If we don't want to drop UDP, we probably should be pushing messages into the queue instead of trying to handle them in the UDP receive thread: https://github.com/godarklight/KerbalMultiPlayer/blob/master/KMPServer/Server.cs#L1806
