### PR TITLE
Modify profanity implementation. Fixes #660

### DIFF
--- a/KMPServer/ServerSettings.cs
+++ b/KMPServer/ServerSettings.cs
@@ -74,11 +74,13 @@ namespace KMPServer
 						try
 						{
 							//Uses a Enumerable KVP instead of a dictionary to avoid an extra conversion.
-							_profanity = profanityWords.Split(',').Select(ws =>
-							{
-								var wx = ws.Split(':');
-								return new KeyValuePair<string, string>(wx[0], wx[1]);
-							});
+                            _profanity = profanityWords
+                                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                                .Select(x => x.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries))
+                                .ToDictionary(
+                                    s => s.Length > 0 ? s[0] : null,
+                                    s => s.Length > 1 ? s[1] : ""
+                                );  
 						}
 						catch
 						{


### PR DESCRIPTION
Seems to have fixed #660.
Linq query resolves instantly instead of deferring, and there are also some extra array bounds checks in there to be sure.
