### PR TITLE
Turn on connection pooling for SQLite.

### DIFF
--- a/KMPServer/DatabaseHelper.cs
+++ b/KMPServer/DatabaseHelper.cs
@@ -56,7 +56,7 @@ namespace KMPServer
         /// <returns>DatabaseHelper for Database</returns>
         internal static DatabaseHelper CreateForSQLite(String filePath)
         {
-            return new DatabaseHelper("Data Source=" + filePath, DatabaseAttributes.SQLite);
+            return new DatabaseHelper("Data Source=" + filePath + "; Pooling=true; Max Pool Size=100;", DatabaseAttributes.SQLite);
         }
 
         /// <summary>


### PR DESCRIPTION
EDIT: Hold. Crashes on new databases :(

Because the new database system opens a new connection for each query, things start to get real slow.

The way around this is to enable connection pooling for sqlite, which is enabled on mysql by default, but not for sqlite. We should also remove that pooled connection thingy in the helper as pooling is defined in the connection string.

We should explicitly close the connections, but I haven't the foggiest about how to do that in an object orientated helper.

I assume they go out of scope and the garbage collector gets them, which leaves the connections open for much longer than they have to be.
