### PR TITLE
Fix all the things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.a
 *.moc
 .git
+*.orig
 
 # Logs etc.
 **/*.log

--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -3760,7 +3760,7 @@ namespace KMP
 					if (skewMessage != null) {
 						skewMessage.duration = 0f;
 					}
-					if (isInFlight) {
+					if (isInFlight && FlightGlobals.ActiveVessel != null) {
 						krakensBaneWarp(skewTargetTick + timeFromLastSyncSecondsAdjusted);
 					} else {
 						Planetarium.SetUniversalTime(skewTargetTick + timeFromLastSyncSecondsAdjusted);

--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -822,12 +822,17 @@ namespace KMP
 
 			if (!docking) writePrimaryUpdate();
 			
-			//nearby vessels
-            if (isInFlight
-			    && !syncing && !warping
-			    && !isInSafetyBubble(FlightGlobals.ship_position,FlightGlobals.ActiveVessel.mainBody,FlightGlobals.ActiveVessel.altitude)
-			    && (serverVessels_IsMine.ContainsKey(FlightGlobals.ActiveVessel.id) ? serverVessels_IsMine[FlightGlobals.ActiveVessel.id] : true))
-			{
+            bool activeVesselOk = false;
+            bool activeVesselIsInBubble = false;
+            bool activeVesselIsMine = false;
+            if (FlightGlobals.ActiveVessel != null)
+            {
+                activeVesselOk = true;
+                activeVesselIsInBubble = isInSafetyBubble(FlightGlobals.ship_position, FlightGlobals.ActiveVessel.mainBody, FlightGlobals.ActiveVessel.altitude);
+                activeVesselIsMine = (serverVessels_IsMine.ContainsKey(FlightGlobals.ActiveVessel.id) ? serverVessels_IsMine[FlightGlobals.ActiveVessel.id] : true);
+            }
+            if (isInFlight && !syncing && !warping && activeVesselOk && !activeVesselIsInBubble && activeVesselIsMine) {
+                //nearby vessels
 				writeSecondaryUpdates();
 			}
 		}

--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -392,7 +392,11 @@ namespace KMP
                         {
                             if (numberOfShips != 0)
                             {
-                                vesselLoadedMessage = ScreenMessages.PostScreenMessage("Synchronizing vessels: " + vesselUpdatesLoaded.Count + "/" + numberOfShips + " (" + (vesselUpdatesLoaded.Count * 100 / numberOfShips) + "%)", 1f, ScreenMessageStyle.UPPER_RIGHT);
+                                if (!vesselsLoaded) {
+                                    vesselLoadedMessage = ScreenMessages.PostScreenMessage("Synchronizing vessels: " + vesselUpdatesLoaded.Count + "/" + numberOfShips + " (" + (vesselUpdatesLoaded.Count * 100 / numberOfShips) + "%)", 1f, ScreenMessageStyle.UPPER_RIGHT);
+                                } else {
+                                    vesselLoadedMessage = ScreenMessages.PostScreenMessage("Universe synchronized!",1f,ScreenMessageStyle.UPPER_RIGHT);
+                                }
                             }
                             else
                             {
@@ -3664,7 +3668,6 @@ namespace KMP
             if (!forceQuit && syncing && gameRunning)
             {
                 vesselsLoaded = true;
-                ScreenMessages.PostScreenMessage("Universe synchronized",1f,ScreenMessageStyle.UPPER_RIGHT);
                 Invoke("finishSync", 3f);
             }
         }

--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -920,11 +920,22 @@ namespace KMP
 
 					switch (HighLogic.LoadedScene)
 					{
-						case GameScenes.FLIGHT:
-							if (serverVessels_IsMine.ContainsKey(FlightGlobals.ActiveVessel.id) ? serverVessels_IsMine[FlightGlobals.ActiveVessel.id] : true)
-								status_array[1] = "Preparing/launching from KSC";
-							else
-								status_array[1] = "Spectating " + FlightGlobals.ActiveVessel.vesselName;
+                        case GameScenes.FLIGHT:
+                            if (FlightGlobals.ActiveVessel != null)
+                            {
+                                if (serverVessels_IsMine.ContainsKey(FlightGlobals.ActiveVessel.id) ? serverVessels_IsMine[FlightGlobals.ActiveVessel.id] : true)
+                                {
+                                    status_array[1] = "Preparing/launching from KSC";
+                                }
+                                else
+                                {
+                                    status_array[1] = "Spectating " + FlightGlobals.ActiveVessel.vesselName;
+                                }
+                            }
+                            else
+                            {
+                                status_array[1] = "Preparing/launching from KSC";
+                            }
 							break;
 						case GameScenes.SPACECENTER:
 							status_array[1] = "At Space Center";

--- a/KMPManager.cs
+++ b/KMPManager.cs
@@ -3628,9 +3628,12 @@ namespace KMP
 		}
 		
 		private void setNotWarping()
-		{
-			warping = false;	
-		}
+        {
+            if (TimeWarp.CurrentRate <= 1)
+            {
+                warping = false;	
+            }
+        }
 		
 		private void OnFirstFlightReady()
 		{


### PR DESCRIPTION
These changes should be sane to merge, but I'd still like to tack the space center bug fix onto this one if I can find the problem.

FlightGlobals.ActiveVessel can go null in stupid places, so we need to check out things before we start using it. This was a throw in the log but not the space center bug. https://github.com/godarklight/KerbalMultiPlayer/commit/b776f4c4b2cca6a5d0b7170ea21d2af7e1ed6551

~~The space center bug was fun to track down - I eventually discovered that it happens while you are at the space center but ActiveVessel is null. Setting it didn't help, and then I saw a tiny give away in the logs, the throw in FloatingOrigin.~~

~~FloatingOrigin is KrakensBane's friend - Something shady must happen inside of KSP when we call SetOffset while ActiveVessel is null.~~ _Sigh_, still happens.

~~https://github.com/godarklight/KerbalMultiPlayer/commit/76928bff2c5d45f826e0e93046cbb34eae0cb4ec skips krakensbane while ActiveVessel is null.~~

I'm unsure what is causing FloatingOrigin to throw, I noticed that every time it would lock up the active vessel (syncplate) vessel seems to be packed just before it uses the krakensbane shift - But after simply setting the time if it was packed, or waiting until the syncplate was unpacked before even starting the NTP sync did not help. Replacing the whole method with my krakensbane from orbit doesn't fix things, FloatingOrigin throws without touching krakensbane: https://github.com/godarklight/KerbalMultiPlayer/blob/current-orbital-parameters/KMPManager.cs#L3416-L3451.

Perhaps KSP is cursed?

~~EDIT:  dockedKickToTrackingStation calls OnFirstFlightReady which I've broke - I'll edit that commit when I can work out the rest of the story :-/~~ Should be fixed with b0337fbf279d1204f3af048553990cb3578db6f9

~~Now to work out the space center bug...~~
You have to take the red pill to see how deep this rabit hole goes. A single throw looks like it stops things from working.
Step 1:
https://github.com/TehGimp/KerbalMultiPlayer/blob/1b891bb7b438e483f91762d7416cd4dd2a817b07/KMPManager.cs#L3901
Step 2:
https://github.com/TehGimp/KerbalMultiPlayer/blob/1b891bb7b438e483f91762d7416cd4dd2a817b07/KMPManager.cs#L823
First failure that may have prevented this, Too important to not insta-fix: https://github.com/TehGimp/KerbalMultiPlayer/blob/1b891bb7b438e483f91762d7416cd4dd2a817b07/KMPManager.cs#L849
Step 3: https://github.com/TehGimp/KerbalMultiPlayer/blob/1b891bb7b438e483f91762d7416cd4dd2a817b07/KMPManager.cs#L856
Step 4: SyncPlate gets added to remote vessels, returns: https://github.com/TehGimp/KerbalMultiPlayer/blob/1b891bb7b438e483f91762d7416cd4dd2a817b07/KMPManager.cs#L1348
Step 5: Sends it off to interop https://github.com/TehGimp/KerbalMultiPlayer/blob/1b891bb7b438e483f91762d7416cd4dd2a817b07/KMPManager.cs#L956

Things are pretty normal up to this point, then KMP has a run of bad luck.

Step 6 (long story short), Krakensbane warp gets called when the syncplate is unpacked, packs the sync plate due to a logic problem, this also freaks out FloatingOrigin (I think):
https://github.com/TehGimp/KerbalMultiPlayer/blob/master/KMPManager.cs#L3710-L3711

Some magic happens, I'm unsure how we get to this point anyway, but I'm fairly sure the actual bug happens somewhere around here:
https://github.com/TehGimp/KerbalMultiPlayer/blob/master/KMPManager.cs#L1108
https://github.com/TehGimp/KerbalMultiPlayer/blob/master/KMPManager.cs#L1099
Every time you press on a space center building it makes around 5 exceptions.
