### PR TITLE
add KSP-AVC version file for auto-module checking

### DIFF
--- a/KMPClient.version
+++ b/KMPClient.version
@@ -6,5 +6,10 @@
     "MINOR": 1,
     "PATCH": 5,
     "BUILD": 1
+  },
+  "KSP_VERSION": {
+    "MAJOR": 0,
+    "MINOR": 23,
+    "PATCH": 5
   }
 }

--- a/KMPClient.version
+++ b/KMPClient.version
@@ -1,0 +1,10 @@
+{
+  "NAME": "KMP - Client",
+  "URL": "https://raw.githubusercontent.com/TehGimp/KerbalMultiPlayer/master/KMPClient.version",
+  "VERSION": {
+    "MAJOR": 0,
+    "MINOR": 1,
+    "PATCH": 5,
+    "BUILD": 1
+  }
+}

--- a/KMPServer.version
+++ b/KMPServer.version
@@ -6,5 +6,10 @@
     "MINOR": 1,
     "PATCH": 5,
     "BUILD": 1
+  },
+  "KSP_VERSION": {
+    "MAJOR": 0,
+    "MINOR": 23,
+    "PATCH": 5
   }
 }

--- a/KMPServer.version
+++ b/KMPServer.version
@@ -1,0 +1,10 @@
+{
+  "NAME": "KMP - Server",
+  "URL": "https://raw.githubusercontent.com/TehGimp/KerbalMultiPlayer/master/KMPServer.version",
+  "VERSION": {
+    "MAJOR": 0,
+    "MINOR": 1,
+    "PATCH": 5,
+    "BUILD": 1
+  }
+}


### PR DESCRIPTION
Dearest KMP authors/maintainers,

I just started working with @tyrope on a project to add a version checker to KSP modules. I know that it would help me a lot! He said that helping him contact module authors would be really helpful so here I am! If you would be willing to accept this patch we would really appreciate it!

The KSP Addon Version Checker is my attempt at trying to have some sort of version checking available for people who play KSP with lots of mods. more information and source available [right here on github](https://github.com/tyrope/KSP-addon-version-checker)

**Note:** I tried my best to figure out where these files should go. It looks like there's an intermediary step involved in making the zip file but I don't speak C# so I wasn't able to find it. I also wasn't sure whether the client and the server would need their own versions. Guidance would be appreciated! :)
